### PR TITLE
fix #100 update must specify both set and unset

### DIFF
--- a/server-nodejs/index.js
+++ b/server-nodejs/index.js
@@ -17,7 +17,7 @@ var https   = require('https')
 /*
  * Mongo model
  */
-var mongoModel = require('../model.js');
+var mongoModel = require('./model.js');
 app.locals.mod = new mongoModel();
 app.locals.mod.connection(function () { });
 var mod = app.locals.mod;

--- a/server-nodejs/model.js
+++ b/server-nodejs/model.js
@@ -166,7 +166,8 @@ module.exports = function Model()
 		debug('update nodes: ', ids);
 		debug('update keys: ', keys);
 		var keysToUnset = {},
-			keysToSet = {};
+			keysToSet = {},
+			toUpdate = {};
 		// prepare ids
 		var ids_o = new Array();
 		for (var i = 0; i < ids.length; i++)
@@ -184,6 +185,15 @@ module.exports = function Model()
 				keysToSet[k] = decodeURIComponent(keys[k]);
 			}
 		}
+
+		//Mongo cannot set or unset empty keys
+		if (Object.keys(keysToSet).length > 0) {
+			toUpdate.$set = keysToSet;
+		}
+		if (Object.keys(keysToUnset).length > 0) {
+			toUpdate.$unset = keysToUnset;
+		}
+
 		this.connection( function(err, database )
 		{
 			if( err )
@@ -201,7 +211,7 @@ module.exports = function Model()
 					else
 					{
 
-						collection.update( { '_id': {$in:ids_o} }, { $set:keysToSet, $unset:keysToUnset}, {multi: true}, function( err, result)
+						collection.update( { '_id': {$in:ids_o} }, toUpdate, {multi: true}, function( err, result)
 						{
 							if( err )
 							{

--- a/server-nodejs/model.js
+++ b/server-nodejs/model.js
@@ -165,9 +165,9 @@ module.exports = function Model()
 	{
 		debug('update nodes: ', ids);
 		debug('update keys: ', keys);
-		var keysToUnset = {},
-			keysToSet = {},
-			toUpdate = {};
+		var keysToUnset = {};
+		var keysToSet = {};
+		var toUpdate = {};
 		// prepare ids
 		var ids_o = new Array();
 		for (var i = 0; i < ids.length; i++)
@@ -186,7 +186,7 @@ module.exports = function Model()
 			}
 		}
 
-		//Mongo cannot set or unset empty keys
+		//Mongo >= 2.6 Update operators must specify a non-empty operand expression
 		if (Object.keys(keysToSet).length > 0) {
 			toUpdate.$set = keysToSet;
 		}


### PR DESCRIPTION
This is a simple way to fix the bug.

I also thought about something like that : 

```javascript
var keysToUpdate = {};
for( var k in keys )
{
	if( keys[k] === null )
	{
		keysToUpdate.$unset[k] = '';
	}
	else
	{
		keysToUpdate.$set[k] = decodeURIComponent(keys[k]);
	}
}
```

The problem is arrays $unset and $set are not instantiated. If we instantiate them before, the bug is the same