### PR TITLE
Fix #76 (server event layer)

### DIFF
--- a/server-nodejs/events.js
+++ b/server-nodejs/events.js
@@ -4,10 +4,52 @@
  */
 
 var listeners = {};
+var manager = module.exports = new EventManager();
 
-module.exports = new EventLayer();
 
-function EventLayer() {
+/*
+ * EventContext()
+ * Constructor for a context object for event listeners
+ */
+function EventContext(name, id, data) {
+    this.next = id + 1;
+    this.data = data;
+    this.listener = listeners[name][id];
+
+    /*
+     * detach()
+     * Detach the current event listener
+     */
+    this.detach = function () {
+        manager.detach(name, listeners[name][id]);
+        --this.next;
+    };
+
+
+    /*
+     * attach()
+     * Attach another listener to the current event
+     */
+    this.attach = function (callback) {
+        manager.attach(name, callback);
+    };
+
+
+    /*
+     * interrupt()
+     * Interrupt the event (don't call other listeners)
+     */
+    this.interrupt = function () {
+        this.next = listeners[name].length;
+    };
+}
+
+
+/*
+ * EventManager()
+ * Set of methods to easily and agnostically manage events
+ */
+function EventManager() {
     var self = this;
 
     /*
@@ -15,16 +57,21 @@ function EventLayer() {
      * Fire an event: call all of its listeners
      */
     this.fire = function (hook) {
-        var args = [];
-        for (var i = 1; i < arguments.length; ++i) {
-            args.push(arguments[i]);
-        }
+        var data = {};
         if (hook in listeners) {
-            for (var id of Object.keys(listeners[hook])) {
-                // Call the listener using itself as a context
-                listeners[hook][id].apply(listeners[hook][id], args);
+            var args = [];
+            for (var i = 1; i < arguments.length; ++i) {
+                args.push(arguments[i]);
+            }
+            for (var l = 0; l < listeners[hook].length;) {
+                var context = new EventContext(hook, l, data);
+                listeners[hook][l].apply(context, args);
+
+                data = context.data;
+                l = context.next;
             }
         }
+        return data;
     }; // fire()
 
 
@@ -44,12 +91,11 @@ function EventLayer() {
      * attach()
      * Attach an event listener to an event
      */
-    this.attach = function (hook, id, callback) {
+    this.attach = function (hook, callback) {
         if (!(hook in listeners)) {
-            listeners[hook] = {};
+            listeners[hook] = [];
         }
-        // Note that we allow the override of existing listeners
-        listeners[hook][id] = callback;
+        listeners[hook].push(callback);
     }; // attach()
 
 
@@ -57,9 +103,12 @@ function EventLayer() {
      * detach()
      * Detach an event listener
      */
-    this.detach = function (hook, id) {
-        if (hook in listeners && id in listeners[hook]) {
-            delete listeners[hook][id];
+    this.detach = function (hook, callback) {
+        if (hook in listeners) {
+            var i = listeners[hook].indexOf(callback);
+            if (-1 !== i) {
+                listeners[hook].splice(i, 1);
+            }
         }
     }; // detach()
 }

--- a/server-nodejs/events.js
+++ b/server-nodejs/events.js
@@ -1,0 +1,63 @@
+/*
+ * events.js - from Damas-Core
+ * Licensed under the GNU GPL v3
+ */
+
+var listeners = {};
+
+module.exports = {
+    /*
+     * fire()
+     * Fire an event: call all of its listeners
+     */
+    fire: function (hook) {
+        var args = [];
+        for (var i = 1; i < arguments.length; ++i) {
+            args.push(arguments[i]);
+        }
+        if (hook in listeners) {
+            for (var id of Object.keys(listeners[hook])) {
+                // Call the listener using itself as a context
+                listeners[hook][id].apply(listeners[hook][id], args);
+            }
+        }
+    }, // fire()
+
+
+    /*
+     * afire()
+     * Asynchronously fire events
+     */
+    afire: function () {
+        var args = arguments;
+        setTimeout(function () {
+            self.fire.apply(self.fire, args);
+        }, 0);
+    }, // afire()
+
+
+    /*
+     * attach()
+     * Attach an event listener to an event
+     */
+    attach: function (hook, id, callback) {
+        if (!(hook in listeners)) {
+            listeners[hook] = {};
+        }
+        // Note that we allow the override of existing listeners
+        listeners[hook][id] = callback;
+    }, // attach()
+
+
+    /*
+     * detach()
+     * Detach an event listener
+     */
+    detach: function (hook, id) {
+        if (hook in listeners && id in listeners[hook]) {
+            delete listeners[hook][id];
+        }
+    }, // detach()
+};
+
+

--- a/server-nodejs/events.js
+++ b/server-nodejs/events.js
@@ -11,19 +11,18 @@ var manager = module.exports = new EventManager();
  * EventContext()
  * Constructor for a context object for event listeners
  */
-function EventContext(name, id, data) {
-    this.next = id + 1;
-    this.data = data;
+function EventContext(name) {
+    this.next = 1;
+    this.data = {};
     this.name = name;
-    this.listener = listeners[name][id];
+    this.listener = listeners[name][this.next - 1];
 
     /*
      * detach()
      * Detach the current event listener
      */
     this.detach = function () {
-        manager.detach(name, listeners[name][id]);
-        --this.next;
+        manager.detach(name, listeners[name][--this.next]);
     };
 
 
@@ -58,21 +57,18 @@ function EventManager() {
      * Fire an event: call all of its listeners
      */
     this.fire = function (hook) {
-        var data = {};
+        var ctx = new EventContext(hook);
         if (hook in listeners) {
             var args = [];
             for (var i = 1; i < arguments.length; ++i) {
                 args.push(arguments[i]);
             }
-            for (var l = 0; l < listeners[hook].length;) {
-                var context = new EventContext(hook, l, data);
-                listeners[hook][l].apply(context, args);
-
-                data = context.data;
-                l = context.next;
+            while (ctx.next <= listeners[hook].length) {
+                listeners[hook][ctx.next - 1].apply(ctx, args);
+                ++ctx.next;
             }
         }
-        return data;
+        return ctx.data;
     }; // fire()
 
 

--- a/server-nodejs/events.js
+++ b/server-nodejs/events.js
@@ -5,12 +5,16 @@
 
 var listeners = {};
 
-module.exports = {
+module.exports = new EventLayer();
+
+function EventLayer() {
+    var self = this;
+
     /*
      * fire()
      * Fire an event: call all of its listeners
      */
-    fire: function (hook) {
+    this.fire = function (hook) {
         var args = [];
         for (var i = 1; i < arguments.length; ++i) {
             args.push(arguments[i]);
@@ -21,43 +25,43 @@ module.exports = {
                 listeners[hook][id].apply(listeners[hook][id], args);
             }
         }
-    }, // fire()
+    }; // fire()
 
 
     /*
      * afire()
      * Asynchronously fire events
      */
-    afire: function () {
+    this.afire = function () {
         var args = arguments;
         setTimeout(function () {
             self.fire.apply(self.fire, args);
         }, 0);
-    }, // afire()
+    }; // afire()
 
 
     /*
      * attach()
      * Attach an event listener to an event
      */
-    attach: function (hook, id, callback) {
+    this.attach = function (hook, id, callback) {
         if (!(hook in listeners)) {
             listeners[hook] = {};
         }
         // Note that we allow the override of existing listeners
         listeners[hook][id] = callback;
-    }, // attach()
+    }; // attach()
 
 
     /*
      * detach()
      * Detach an event listener
      */
-    detach: function (hook, id) {
+    this.detach = function (hook, id) {
         if (hook in listeners && id in listeners[hook]) {
             delete listeners[hook][id];
         }
-    }, // detach()
-};
+    }; // detach()
+}
 
 

--- a/server-nodejs/events.js
+++ b/server-nodejs/events.js
@@ -14,6 +14,7 @@ var manager = module.exports = new EventManager();
 function EventContext(name, id, data) {
     this.next = id + 1;
     this.data = data;
+    this.name = name;
     this.listener = listeners[name][id];
 
     /*

--- a/server-nodejs/events.js
+++ b/server-nodejs/events.js
@@ -35,13 +35,13 @@ function EventManager() {
                 listener: null
             };
 
-            function call() {
-                if (next === listeners[hook].length) {
+            function call(number) {
+                if (number === listeners[hook].length) {
                     then(ctx.data);
-                    return;
+                } else if (number < listeners[hook].length) {
+                    ctx.listener = listeners[hook][number];
+                    ctx.listener.apply(ctx, args);
                 }
-                ctx.listener = listeners[hook][next++];
-                ctx.listener.apply(ctx, args);
             }
 
             /*
@@ -58,9 +58,15 @@ function EventManager() {
                 self.attach(hook, callback);
             };
 
+            // Stop the event
+            ctx.end = function () {
+                next = listeners[hook].length;
+                ctx.next();
+            };
+
             // Run asynchronously the next listener
             ctx.next = function () {
-                process.nextTick(call);
+                process.nextTick(function () { call (next++); });
             };
             ctx.next();
         }


### PR DESCRIPTION
## UPDATE
See the next comments in order to stay up to date. The major part of this one has been stripped in order to keep the messages clean (I only kept the "Go further" and "Sample code" sections, to quickly show the differences between the two versions).

---

### Go further

- The comments are improvable with documentation-generators' syntax (`@something`).
- We could imagine a "priority" system, allowing to attach listeners while specifying their priority, to sort them and run them in a specific order.
- It should be better to `this.attach()` new listeners to the next run instead of the current one.
- If there are 3 times the same listener, and the last one calls `this.detach()`, it will detach the first one.
- It might be interesting to add support for regexes (ie, listen for `.*create.*` will listen simultaneously for `pre-create`, `created`, `create-comment`, etc).
- `interrupt()` is stupid when listeners run asynchronous code. We have to wait until the listener finished its processing - in other words, let each listener call the `next()` one.

### Sample code

```javascript
var events = require('./events');
var count = 0;

function testFire() {
    this.data[++count] = 'fired event ' + this.name;
}

function testArguments() {
    this.data[++count] = arguments;
}

function testDetach() {
    this.data[++count] = 'detaching from ' + this.name;
    this.detach();
}

function testAttach() {
    this.data[++count] = 'attaching testArguments to ' + this.name;
    this.attach(testArguments);
}

// Attach listeners

events.attach('test', testFire);
events.attach('test', testDetach);
events.attach('test', testAttach);
events.attach('test', testFire);

// Run tests

count = 0;
console.log(events.fire('test', 'arg10', 'arg11', 'arg12'));
console.log();

count = 0;
events.detach('test', testFire); // remove the first testFire listener
events.detach('test', testAttach); // remove the first testAttach listener
console.log(events.fire('test', 'arg20', 'arg21', 'arg22'));
console.log();
```
Output
```javascript
{ '1': 'fired event test',
  '2': 'detaching from test',
  '3': 'attaching testArguments to test',
  '4': 'fired event test',
  '5': { '0': 'arg10', '1': 'arg11', '2': 'arg12' } }

{ '1': 'fired event test',
  '2': { '0': 'arg20', '1': 'arg21', '2': 'arg22' } }
```
The listener '2' detached itself during the first run.
The listeners '1' and '3' from the first run are detached before the second run.