### PR TITLE
Fix #120 (Autodetect identifier)

### DIFF
--- a/server-nodejs/db/index.js
+++ b/server-nodejs/db/index.js
@@ -16,6 +16,10 @@ module.exports = function (type, settings) {
         var dbClass = require('./mongodb');
         db = new dbClass(settings);
         break;
+    case 'mongodb-fileids':
+        var dbClass = require('./mongodb-fileids');
+        db = new dbClass(settings);
+        break;
     default:
         var dbClass = require('./debug');
         db = new dbClass(settings);

--- a/server-nodejs/db/mongodb-fileids.js
+++ b/server-nodejs/db/mongodb-fileids.js
@@ -148,6 +148,7 @@ module.exports = function (conf) {
     self.update = function (nodes, callback) {
         getCollection(callback, function (coll) {
             array_sync(nodes, function (node, cb) {
+                // Replace the updated id
                 node._id = Array.isArray(node._id) ? node._id : [node._id];
                 var ids = exportIds(node._id);
                 var obj = {$or: [{_id: {$in: []}}, {file: {$in: []}}]};
@@ -158,6 +159,8 @@ module.exports = function (conf) {
                 if (node.set && node.set.file) {
                     node._id.concat(node.set.file);
                 }
+
+                // Separate update operations
                 var update = { };
                 if (node.set && Object.keys(node.set).length > 0) {
                     update.$set = node.set;
@@ -347,7 +350,7 @@ module.exports = function (conf) {
             case ObjectID.isValid(ids[i]):
                 var id = {_id: new ObjectID(ids[i])};
                 break;
-            case 'object' === typeof ids[i] && 0 < Object.keys(ids[i]).length:
+            case 'object' === typeof ids[i] && (ids[i]._id || ids[i].file):
                 if (Array.isArray(ids[i]._id || ids[i].file)) {
                     var id = exportIds(ids[i]._id || ids[i].file);
                 } else {

--- a/server-nodejs/db/mongodb-fileids.js
+++ b/server-nodejs/db/mongodb-fileids.js
@@ -347,15 +347,14 @@ module.exports = function (conf) {
             case ObjectID.isValid(ids[i]):
                 var id = {_id: new ObjectID(ids[i])};
                 break;
-            case 'object' === typeof ids[i]:
-                var id = ids[i]._id || ids[i].file;
-                if (id && Array.isArray(id)) {
-                    id = exportIds(id);
-                } else if (0 < Object.keys(ids[i]).length) {
-                    id = ids[i];
+            case 'object' === typeof ids[i] && 0 < Object.keys(ids[i]).length:
+                if (Array.isArray(ids[i]._id || ids[i].file)) {
+                    var id = exportIds(ids[i]._id || ids[i].file);
+                } else {
+                    var id = ids[i];
                 }
                 break;
-            case 'string' === typeof ids[i] && -1 !== ids[i].indexOf('/'):
+            case 'string' === typeof ids[i] && -1 < ids[i].indexOf('/'):
                 var id = {file: ids[i]};
                 break;
             default:

--- a/server-nodejs/db/mongodb-fileids.js
+++ b/server-nodejs/db/mongodb-fileids.js
@@ -1,0 +1,429 @@
+/*
+ * lib/db/mongodb.js - from Damas-Core
+ * Licensed under the GNU GPL v3
+ */
+
+function array_sync(array, walker, callback) {
+    var next = 0;
+    var results = [];
+    (function walk() {
+        if (next === array.length) {
+            callback(results);
+            ++next;
+        } else if (next < array.length) {
+            walker(array[next++], function (result) {
+                results = results.concat(result);
+                process.nextTick(walk);
+            });
+        }
+    })();
+}
+
+var events = require('../events');
+/*
+ * Attempt to fire an event, if the given array is valid
+ */
+function fireEvent(name, array) {
+    var clean = array.filter(function (item) { return item !== null; });
+    if (0 < clean.length) {
+        events.fire(name, clean);
+    }
+}
+
+module.exports = function (conf) {
+    var self = this;
+    self.conf = conf;
+    self.conn = false;
+    self.collection = false;
+    self.debug = require('debug')('app:db:mongo:' + process.pid);
+
+    var mongo = require('mongodb');
+    var ObjectID = mongo.ObjectID;
+
+    /*
+     * Initialize the connection.
+     * @param {object} conf - Database settings
+     * @param {function} callback - Callback function to routes.js
+     */
+    self.connect = function (callback) {
+        if (self.conn) {
+            callback(false, self.conn);
+            return;
+        }
+        var conf = self.conf;
+        var server = new mongo.Server(conf.host, conf.port, conf.options);
+        var db = new mongo.Db(conf.collection, server);
+        db.open(function (err, connection) {
+            if (err) {
+                self.debug('Unable to connect to the MongoDB database');
+                callback(true);
+                return;
+            }
+            self.debug('Connected to the database');
+            self.conn = connection;
+            self.collection = conf.collection;
+            callback(false, self.conn);
+        });
+    }; // connect()
+
+    /*
+     * Load the collection
+     * @param {function} route - Callback function in case of failure
+     * @param {function} callback - Function needing the collection
+     */
+    function getCollection (route, callback) {
+        self.connect(function (err, conn) {
+            if (err || !conn) {
+                route(true);
+                return;
+            }
+            self.conn.collection(self.collection, function (err, coll) {
+                if (err || !coll) {
+                    self.debug('Error: unable to load the collection');
+                    route(true);
+                    return;
+                }
+                callback(coll);
+            });
+        });
+    };
+
+
+    /*
+     * Minimal CRUDS operations
+     */
+
+    /**
+     * Create nodes, without parent verification.
+     * @param {array} nodes - Objects to create in the database
+     * @param {function} callback - function({boolean} err, {array} nodes)
+     */
+    self.create = function (nodes, callback) {
+        getCollection(callback, function (coll) {
+            array_sync(nodes, function (node, cb) {
+                if (node._id || node.file) {
+                    var ids = exportIds([node._id || node.file]);
+                    delete node._id, node.file;
+                    let nodeStub = JSON.stringify(node);
+                    node = [];
+                    for (let i = 0; i < ids.length; ++i) {
+                        node[i] = JSON.parse(nodeStub);
+                        let key = ids[i]._id ? '_id' : 'file';
+                        node[i][key] = ids[i][key];
+                    }
+                }
+                coll.insert(node, {safe: true}, function (err, result) {
+                    cb(err ? null : result.ops);
+                });
+            }, function (array) {
+                callback(false, array);
+                fireEvent('create', array);
+            });
+        });
+    }; // create()
+
+    /**
+     * Retrieve nodes as key->value objects.
+     * @param {array} ids - Identifiers of the nodes to retrieve.
+     * @param {function} callback - Callback function to routes.js
+     */
+    self.read = function (ids, callback) {
+        getCollection(callback, function (coll) {
+            array_sync(exportIds(ids), function (id, cb) {
+                coll.findOne(id, function (err, node) {
+                    cb(err ? null : node);
+                });
+            }, function (array) {
+                callback(false, array);
+            });
+        });
+    }; // read()
+
+    /**
+     * Update nodes. Existing values are overwritten, null removes the key.
+     * @param {array} ids - Identifiers of the nodes to update
+     * @param {object} keys - New keys to define on the nodes
+     * @param {function} callback - Callback function to routes.js
+     */
+    self.update = function (nodes, callback) {
+        getCollection(callback, function (coll) {
+            array_sync(nodes, function (node, cb) {
+                node._id = Array.isArray(node._id) ? node._id : [node._id];
+                var ids = exportIds(node._id);
+                var obj = {$or: [{_id: {$in: []}}, {file: {$in: []}}]};
+                for (let i = 0; i < ids.length; ++i) {
+                    let key = ids[i]._id ? '_id' : 'file';
+                    obj.$or[key === '_id' ? 0 : 1][key].$in.push(ids[i][key]);
+                }
+                if (node.set && node.set.file) {
+                    node._id.concat(node.set.file);
+                }
+                var update = { };
+                if (node.set && Object.keys(node.set).length > 0) {
+                    update.$set = node.set;
+                }
+                if (node.unset && Object.keys(node.unset).length > 0) {
+                    update.$unset = node.unset;
+                }
+                coll.update(obj, update, {multi: true},
+                        function (err, status) {
+                    if (err) {
+                        return cb(null);
+                    }
+                    self.read(node._id, function (err, doc) {
+                        cb(err ? null : doc);
+                    });
+                });
+            }, function (array) {
+                callback(false, array);
+                fireEvent('update', array);
+            });
+        });
+    }; // update()
+
+    /**
+     * Delete specified nodes.
+     * @param {array} ids - List of node ids to delete
+     * @param {function} callback - Callback function to routes.js
+     */
+    self.remove = function (ids, callback) {
+        getCollection(callback, function (coll) {
+            array_sync(exportIds(ids), function (id, cb) {
+                coll.remove(id, function (err, result) {
+                    if (err || 0 === result.result.n) {
+                        cb(null);
+                    } else {
+                        cb(id._id || id.file);
+                    }
+                });
+            }, function (array) {
+                callback(false, array);
+                fireEvent('remove', array);
+            });
+        });
+    }; // remove()
+
+    /**
+     * Search for nodes ids in the database.
+     * @param {object} keys - Keys to find
+     * @param {function} callback - Callback function to routes.js
+     */
+    self.search = function (keys, callback) {
+        getCollection(callback, function (coll) {
+            coll.find(keys, {_id: true}).toArray(function (err, results) {
+                if (err) {
+                    callback(true);
+                    return;
+                }
+                var ids = [];
+                for (r in results) {
+                    ids.push(results[r]._id.toString());
+                }
+                callback(false, ids);
+            });
+        });
+    }; // search()
+
+    self.searchFromText = function (str, callback) {
+        self.search(textSearch2MongoQuery(str), callback);
+    };
+
+    /*
+     * Higher-level functions
+     */
+
+    function links_r (ids, links, callback) {
+        var newIds = [];
+        if (links == null) {
+            links=[];
+        }
+        getCollection(callback, function (coll) {
+            coll.find({tgt_id: {$in: ids}}).toArray(function (err, results) {
+                if (err) {
+                    callback(true);
+                    return;
+                }
+                for (var r in results) {
+                    if (undefined == links[results[r]._id]) {
+                        if (results[r].src_id != undefined) {
+                            if (0 > ids.indexOf(results[r].src_id)) {
+                                newIds.push(results[r].src_id);
+                            }
+                        }
+                        links[results[r]._id] = results[r];
+                    }
+                }
+                if (newIds.length < 1) {
+                    callback(false, links);
+                } else {
+                    links_r(newIds, links, callback);
+                }
+            });
+        });
+    }; // links_r()
+
+
+    /**
+     * Retrieve the graph of the specified target nodes
+     * @param {Array} ids - Array of node indexes
+     * @param {Function} callback - function (err, result) to call
+     */
+    self.graph = function (ids, callback){
+        links_r(ids, null, function (err, links) {
+            if (err || !links) {
+                callback(true);
+                return;
+            }
+            var n_ids = ids;
+            for (l in links) {
+                if (undefined != links[l].src_id) {
+                    if (0 > n_ids.indexOf(links[l].src_id)) {
+                        n_ids.push(links[l].src_id);
+                    }
+                }
+            }
+            self.read(n_ids, function (error, nodes) {
+                if (error || !nodes) {
+                    callback(true);
+                    return;
+                }
+                for (var l in links) {
+                    nodes.push(links[l]);
+                }
+                callback(false, nodes);
+            });
+        });
+    }; // graph()
+
+
+    /*
+     * MongoDB-specific functions
+     */
+
+
+    /**
+     * Search for nodes ids in the database.
+     * @param {object} query - Keys to find (with optional regexes)
+     * @param {string} sort - Key used to sort the results
+     * @param {integer} skip - Pagination: number of results to skip
+     * @param {integer} limit - Pagination: max number of results to return
+     * @param {function} callback - Callback function to routes.js
+     */
+    self.mongo_search = function (query, sort, skip, limit, callback) {
+        getCollection(callback, function (coll) {
+            var find = coll.find(query).sort(sort).skip(skip).limit(limit);
+            find.toArray(function (err, results) {
+                if (err) {
+                    callback(true);
+                    return;
+                }
+                var ids = [];
+                for (r in results) {
+                    ids.push(results[r]._id.toString());
+                }
+                callback(false, ids);
+            });
+        });
+    }; // mongo_search()
+
+    // Compatibility
+    // As deleteNode() can actually delete multiple nodes
+    self.deleteNode = function (ids, callback) {
+        self.remove(ids, callback);
+    }; // deleteNode()
+
+    /**
+     * Put all ids into a new array, handling ObjectID and file
+     * @param {array} ids - ids to put
+     * @return {array} - the new array
+     */
+    function exportIds(ids) {
+        var ids_o = [];
+        for (let i = 0; i < ids.length; ++i) {
+            switch (true) {
+            case Array.isArray(ids[i]):
+                var id = exportIds(ids[i]);
+                break;
+            case ObjectID.isValid(ids[i]):
+                var id = {_id: new ObjectID(ids[i])};
+                break;
+            case 'object' === typeof ids[i]:
+                var id = ids[i]._id || ids[i].file;
+                if (id && Array.isArray(id)) {
+                    id = exportIds(id);
+                } else if (0 < Object.keys(ids[i]).length) {
+                    id = ids[i];
+                }
+                break;
+            case 'string' === typeof ids[i] && -1 !== ids[i].indexOf('/'):
+                var id = {file: ids[i]};
+                break;
+            default:
+                var id = {_id: ids[i]};
+            }
+            ids_o = ids_o.concat(id || []);
+        }
+        return ids_o;
+    }
+
+    function textSearch2MongoQuery( str ) {
+        var terms = str.split(' ');
+        var pair;
+        var result = {};
+        for (var i = 0; i < terms.length; i++) {
+            if (terms[i].indexOf('<=') > 0) {
+                pair = terms[i].split('<=');
+                result[pair[0]] = {$lte: pair[1]};
+                continue;
+            }
+            if (terms[i].indexOf('<') > 0) {
+                pair = terms[i].split('<');
+                result[pair[0]] = {$lt: pair[1]};
+                continue;
+            }
+            if (terms[i].indexOf('>=') > 0) {
+                pair = terms[i].split('>=');
+                result[pair[0]] = {$gte: pair[1]};
+                continue;
+            }
+            if (terms[i].indexOf('>') > 0) {
+                pair = terms[i].split('>');
+                result[pair[0]] = {$gt: pair[1]};
+                continue;
+            }
+            if (terms[i].indexOf(':') > 0) {
+                pair = terms[i].split(':');
+                var value = pair[1];
+
+                var flags = value.replace(/.*\/([gimy]*)$/, '$1');
+                var pattern = value.replace(new RegExp('^/(.*?)/' + flags + '$'), '$1');
+                if (flags != value && pattern != value) {
+                    var regex = new RegExp(pattern, flags);
+                    result[pair[0]] = regex;
+                } else {
+                    result[pair[0]] = value;
+                }
+                continue;
+            }
+        }
+        return result;
+    }
+/* implement full text search
+            result['$where'] = function () {
+                for (var key in this) {
+                    if (this[key])
+                }
+            }
+db.things.find({$where: function () {
+  for (var key in this) {
+    if (this[key] === 'bar') {
+      return true;
+    }
+    return false;
+    }
+}});
+*/
+
+};
+
+

--- a/server-nodejs/routes/cruds.js
+++ b/server-nodejs/routes/cruds.js
@@ -147,12 +147,12 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     update = function (req, res) {
-        if (Object.keys(req.body).length === 0) {
+        if (Object.keys(req.body).length === 0 || !req.params.id) {
             httpStatus(res, 400, 'update');
             return;
         }
-
         var ids = req.params.id.split(',');
+        var isArray = ids.length > 1;
         var body = req.body;
         events.fire('pre-update', ids, body).then(function (data) {
             if (data.status) {
@@ -172,7 +172,7 @@ module.exports = function (app, express) {
                 } else if (response.partial) {
                     httpStatus(res, 207, doc);
                 } else {
-                    httpStatus(res, 200, 1 < ids.length ? doc : doc[0]);
+                    httpStatus(res, 200, isArray ? doc : doc[0]);
                 }
             });
         });
@@ -194,7 +194,19 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     deleteNode = function (req, res) {
-        var ids = req.params.id.split(',');
+        if (req.params.id) {
+            var ids = req.params.id.split(',');
+            var isArray = ids.length > 1;
+        } else if (req.body) {
+            var ids = req.body;
+            var isArray = Array.isArray(ids);
+            if (!isArray) {
+                ids = [ids];
+            }
+        } else {
+            httpStatus(res, 400, 'read');
+            return;
+        }
         events.fire('pre-remove', ids).then(function (data) {
             if (data.status) {
                 httpStatus(res, data.status, 'remove');
@@ -230,12 +242,19 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     graph = function (req, res) {
-        var id = req.params.id || req.body.id;
-        if (!id || id == 'undefined') {
-            httpStatus(res, 400, 'graph');
+        if (req.params.id) {
+            var ids = req.params.id.split(',');
+        } else if (req.body) {
+            var ids = req.body;
+            if (!Array.isArray(ids)) {
+                ids = [ids];
+            }
+        } else {
+            httpStatus(res, 400, 'read');
             return;
         }
-        db.graph(id.split(','), function (error, nodes) {
+
+        db.graph(ids, function (error, nodes) {
             if (error) {
                 httpStatus(res, 409, 'graph');
                 return;
@@ -246,7 +265,8 @@ module.exports = function (app, express) {
             } else if (response.partial) {
                 httpStatus(res, 207, nodes);
             } else {
-                httpStatus(res, 200, true ? nodes : nodes[0]); // FIXME
+                // We never need a single element
+                httpStatus(res, 200, nodes);
             }
         });
     }; // graph()
@@ -499,12 +519,16 @@ module.exports = function (app, express) {
     app.post('/api/read/', read);
     app.put('/api/update/:id', update);
     app.delete('/api/delete/:id', deleteNode);
+    app.delete('/api/delete/', deleteNode);
+    app.post('/api/delete/', deleteNode);
 
     // Search operations
     app.get('/api/search/:query(*)', search);
     app.get('/api/search_one/:query(*)', search_one);
     app.post('/api/search_mongo', search_mongo);
-    app.get('/api/graph/', graph);
+    app.get('/api/graph/', graph); // Fix
+    app.get('/api/graph/:id', graph);
+    app.post('/api/graph/', graph);
 
     // CRUD operations (deprecated)
     app.post('/api/', create);
@@ -513,7 +537,6 @@ module.exports = function (app, express) {
     app.delete('/api/:id', deleteNode);
 
     // Extra operations
-    app.get('/api/graph/:id', graph);
     app.get('/api/file/:path(*)', getFile); // untested
     app.post('/api/import', importJSON); // untested
     //app.get('/subdirs/:path', getSubdirs);

--- a/server-nodejs/routes/cruds.js
+++ b/server-nodejs/routes/cruds.js
@@ -60,8 +60,7 @@ module.exports = function (app, express) {
         var time = Date.now();
         for (var n in nodes) {
             if ('object' !== typeof nodes[n]) {
-                httpStatus(res, 400, 'create');
-                return;
+                return httpStatus(res, 400, 'Create');
             }
             nodes[n].author = author;
             nodes[n].time = time;
@@ -69,14 +68,12 @@ module.exports = function (app, express) {
 
         events.fire('pre-create', nodes).then(function (data) {
             if (data.status) {
-                httpStatus(res, data.status, 'create');
-                return;
+                return httpStatus(res, data.status, 'Create');
             }
-            nodes = data.nodes || nodes;
-            db.create(nodes, function (error, doc) {
+            db.create(data.nodes || nodes, function (error, doc) {
                 var response = getMultipleResponse(doc);
                 if (response.fail) {
-                    httpStatus(res, 409, 'create');
+                    httpStatus(res, 409, 'Create');
                 } else if (response.partial) {
                     httpStatus(res, 207, doc);
                 } else {
@@ -112,17 +109,19 @@ module.exports = function (app, express) {
                 ids = [ids];
             }
         } else {
-            httpStatus(res, 400, 'read');
-            return;
+            return httpStatus(res, 400, 'Read');
         }
+        if (ids.some(elem => typeof elem !== 'string')) {
+            return httpStatus(res, 400, 'Read');
+        }
+
         db.read(ids, function (error, doc) {
             if (error) {
-                httpStatus(res, 409, 'read');
-                return;
+                return httpStatus(res, 409, 'Read');
             }
             var response = getMultipleResponse(doc);
             if (response.fail) {
-                httpStatus(res, 404, 'read');
+                httpStatus(res, 404, 'Read');
             } else if (response.partial) {
                 httpStatus(res, 207, doc);
             } else {
@@ -147,32 +146,28 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     update = function (req, res) {
-        if (Object.keys(req.body).length === 0 || !req.params.id) {
-            httpStatus(res, 400, 'update');
-            return;
+        if (0 === Object.keys(req.body).length || !req.params.id) {
+            return httpStatus(res, 400, 'Update');
         }
         var ids = req.params.id.split(',');
         var isArray = ids.length > 1;
         var body = req.body;
         events.fire('pre-update', ids, body).then(function (data) {
             if (data.status) {
-                httpStatus(res, data.status, 'create');
-                return;
+                return httpStatus(res, data.status, 'Update');
             }
-            ids = data.ids || ids;
             body = data.body || body;
-            db.update(ids, body, function (error, doc) {
+            db.update(data.ids || ids, body, function (error, doc) {
                 if (error) {
-                    httpStatus(res, 409, 'update');
-                    return;
+                    return httpStatus(res, 409, 'Update');
                 }
                 var response = getMultipleResponse(doc);
                 if (response.fail) {
-                    httpStatus(res, 404, 'update');
+                    httpStatus(res, 404, 'Update');
                 } else if (response.partial) {
                     httpStatus(res, 207, doc);
                 } else {
-                    httpStatus(res, 200, isArray ? doc : doc[0]);
+                    httpStatus(res, 200, 1 === doc.length ? doc[0] : doc);
                 }
             });
         });
@@ -196,31 +191,26 @@ module.exports = function (app, express) {
     deleteNode = function (req, res) {
         if (req.params.id) {
             var ids = req.params.id.split(',');
-            var isArray = ids.length > 1;
         } else if (req.body) {
-            var ids = req.body;
-            var isArray = Array.isArray(ids);
-            if (!isArray) {
-                ids = [ids];
-            }
+            var ids = Array.isArray(req.body) ? req.body : [req.body];
         } else {
-            httpStatus(res, 400, 'read');
-            return;
+            return httpStatus(res, 400, 'Remove');
+        }
+        if (ids.some(elem => typeof elem !== 'string')) {
+            return httpStatus(res, 400, 'Remove');
         }
         events.fire('pre-remove', ids).then(function (data) {
             if (data.status) {
-                httpStatus(res, data.status, 'remove');
+                return httpStatus(res, data.status, 'Remove');
             }
-            ids = data.ids || ids;
-            db.remove(ids, function (error, doc) {
-                console.log(doc);
+            db.remove(data.ids || ids, function (error, doc) {
                 var response = getMultipleResponse(doc);
                 if (response.fail) {
-                    httpStatus(res, 404, 'remove');
+                    httpStatus(res, 404, 'Remove');
                 } else if (response.partial) {
                     httpStatus(res, 207, doc);
                 } else {
-                    httpStatus(res, 200, 1 < ids.length ? doc : doc[0]);
+                    httpStatus(res, 200, 1 === doc.length ? doc[0] : doc);
                 }
             });
         });
@@ -245,28 +235,25 @@ module.exports = function (app, express) {
         if (req.params.id) {
             var ids = req.params.id.split(',');
         } else if (req.body) {
-            var ids = req.body;
-            if (!Array.isArray(ids)) {
-                ids = [ids];
-            }
+            var ids = Array.isArray(req.body) ? req.body : [req.body];
         } else {
-            httpStatus(res, 400, 'read');
-            return;
+            return httpStatus(res, 400, 'Graph');
+        }
+        if (ids.some(elem => typeof elem !== 'string')) {
+            return httpStatus(res, 400, 'Graph');
         }
 
         db.graph(ids, function (error, nodes) {
             if (error) {
-                httpStatus(res, 409, 'graph');
-                return;
+                return httpStatus(res, 409, 'Graph');
             }
             var response = getMultipleResponse(nodes);
             if (response.fail) {
-                httpStatus(res, 404, 'graph');
+                httpStatus(res, 404, 'Graph');
             } else if (response.partial) {
                 httpStatus(res, 207, nodes);
             } else {
-                // We never need a single element
-                httpStatus(res, 200, nodes);
+                httpStatus(res, 200, nodes); // We never need a single element
             }
         });
     }; // graph()
@@ -287,14 +274,13 @@ module.exports = function (app, express) {
     search = function (req, res) {
         var q = req.params.query || req.body.query;
         if (!q || q == 'undefined') {
-            httpStatus(res, 400, 'search');
-            return;
+            return httpStatus(res, 400, 'Search');
         }
         q = decodeURIComponent(q);
         q = q.replace(/\s+/g, ' ').trim();
         db.searchFromText(q, function (error, doc) {
             if (error) {
-                httpStatus(res, 409, 'search');
+                httpStatus(res, 409, 'Search');
             } else {
                 httpStatus(res, 200, doc);
             }
@@ -317,23 +303,21 @@ module.exports = function (app, express) {
     search_one = function (req, res) {
         var q = req.params.query || req.body.query;
         if (!q || q == 'undefined') {
-            httpStatus(res, 400, 'search_one');
-            return;
+            return httpStatus(res, 400, 'Search_one');
         }
         q = decodeURIComponent(q);
         q = q.replace(/\s+/g, ' ').trim();
         db.searchFromText(q, function (error, doc) {
             if (error) {
-                httpStatus(res, 409, 'search_one');
-            } else {
-                db.read([doc[0]], function (error, nodes) {
-                    if (error) {
-                        httpStatus(res, 409, 'search_one');
-                    } else {
-                        httpStatus(res, 200, nodes[0]);
-                    }
-                });
+                return httpStatus(res, 409, 'Search_one');
             }
+            db.read([doc[0]], function (error, nodes) {
+                if (error) {
+                    httpStatus(res, 409, 'Search_one');
+                } else {
+                    httpStatus(res, 200, nodes[0]);
+                }
+            });
         });
     }; // search_one()
 
@@ -353,8 +337,7 @@ module.exports = function (app, express) {
      */
     search_mongo = function (req, res) {
         if (typeof db.mongo_search !== 'function') {
-            httpStatus(res, 501, 'mongo');
-            return;
+            return httpStatus(res, 501, 'Mongo');
         }
         var query, sort, limit, skip;
         if (req.body.queryobj) {
@@ -376,7 +359,7 @@ module.exports = function (app, express) {
                     continue;
                 }
                 if ('string' === typeof obj[key]) {
-                    if (obj[key].indexOf('REGEX_') === 0) {
+                    if (0 === obj[key].indexOf('REGEX_')) {
                         obj[key] = new RegExp(obj[key].replace('REGEX_', ''));
                     }
                 }
@@ -385,7 +368,7 @@ module.exports = function (app, express) {
         prepare_regexes(query);
         db.mongo_search(query, sort, skip, limit, function (err, ids) {
             if (err) {
-                httpStatus(res, 409, 'search_mongo');
+                httpStatus(res, 409, 'Search_mongo');
             } else {
                 httpStatus(res, 200, ids);
             }
@@ -407,7 +390,7 @@ module.exports = function (app, express) {
                     console.log('ERROR');
                     return;
                 }
-                if (res.length === 0) {
+                if (0 === res.length) {
                     db.create(keys, function (err, n) {
                         if (err) console.log('ERROR create')
                     });
@@ -461,8 +444,7 @@ module.exports = function (app, express) {
         path = path.replace(/:/g, '').replace(/\/+/g, '/');
         fs.exists(path, function (exists) {
             if (!exists) {
-                httpStatus(res, 404, 'file');
-                return;
+                return httpStatus(res, 404, 'File');
             }
             var stream = fs.createReadStream(path, {bufferSize: 64 * 1024});
             res.writeHead(200);
@@ -472,11 +454,9 @@ module.exports = function (app, express) {
 
 
     /**
-     * Sets the appropriate response and status code for multiple params or not
-     * @param {boolean} isArray - did client sent an array or not
+     * Tells whether a response is failed or incomplete (contains null?)
      * @param {array} doc - the database response
-     * @param {} result - the returned object or string
-     * @return {{status: number, content: result}} - the results to send
+     * @return {{fail: boolean, partial: boolean}} - the results to send
      */
     function getMultipleResponse(doc) {
         var result = { fail: true, partial: false };
@@ -502,7 +482,7 @@ module.exports = function (app, express) {
             case 401: e += 'Unauthorized (authentication required)'; break;
             case 403: e += 'Forbidden (permission required)'; break;
             case 404: e += 'Not found'; break;
-            case 409: e += 'Conflict ()'; break;
+            case 409: e += 'Conflict'; break;
             case 501: e += 'Not implemented (contact an administrator)'; break;
             default:  e += 'Unknown error code';
         }
@@ -518,6 +498,7 @@ module.exports = function (app, express) {
     app.get('/api/read/:id', read);
     app.post('/api/read/', read);
     app.put('/api/update/:id', update);
+    app.put('/api/update', update);
     app.delete('/api/delete/:id', deleteNode);
     app.delete('/api/delete/', deleteNode);
     app.post('/api/delete/', deleteNode);
@@ -526,7 +507,7 @@ module.exports = function (app, express) {
     app.get('/api/search/:query(*)', search);
     app.get('/api/search_one/:query(*)', search_one);
     app.post('/api/search_mongo', search_mongo);
-    app.get('/api/graph/', graph); // Fix
+    app.get('/api/graph/', graph); // FIXME for the read error
     app.get('/api/graph/:id', graph);
     app.post('/api/graph/', graph);
 

--- a/server-nodejs/routes/dam.js
+++ b/server-nodejs/routes/dam.js
@@ -22,6 +22,11 @@ module.exports = function (app) {
      */
     app.put('/api/lock/:id', function (req, res) {
         db.read([req.params.id], function (err, n) {
+            if (err) {
+                res.status(400);
+                res.send('lock error, something went wrong');
+                return;
+            }
             if (n[0].lock !== undefined) {
                 res.status(409);
                 res.send('lock error, the asset is already locked');
@@ -58,10 +63,15 @@ module.exports = function (app) {
      */
     app.put('/api/unlock/:id', function (req, res) {
         db.read([req.params.id], function (err, n) {
+            if (err) {
+                res.status(400);
+                res.send('unlock error, something went wrong');
+                return;
+            }
             var user = req.user.username || req.connection.remoteAddress;
             if (n[0].lock !== user) {
                 res.status(409);
-                res.send('lock error, the asset is locked by '+ n[0].lock);
+                res.send('unlock error, the asset is locked by '+ n[0].lock);
                 return;
             }
             var keys = [{
@@ -71,7 +81,7 @@ module.exports = function (app) {
             db.update(keys, function (error, doc) {
                 if (error) {
                     res.status(409);
-                    res.send('lock error, please change your values');
+                    res.send('unlock error, please change your values');
                     return;
                 }
                 res.status(200);

--- a/server-tests/tests-frisby_spec.js
+++ b/server-tests/tests-frisby_spec.js
@@ -201,9 +201,9 @@ frisby.create('CREATE - should create an object in the database')
       * Tests for method Graph
       */
     //it always return a non empty array
-    frisby.create('GRAPH - should throw an error (id empty) - Not found')
+    frisby.create('GRAPH - should throw an error (id empty) - Bad Request')
         .get(url + 'graph/')
-        .expectStatus(404)
+        .expectStatus(400)
     .toss();
 
     frisby.create('GRAPH - should throw an error (id not found) - Not found')
@@ -308,9 +308,9 @@ frisby.create('CREATE - should create an object in the database')
     /**
      * Tests for method Delete
      */
-    frisby.create('DELETE - should throw an error (id empty)')
+    frisby.create('DELETE - should throw an error (id empty) - Bad Request')
         .delete(url + 'delete/')
-        .expectStatus(404)
+        .expectStatus(400)
     .toss();
 
     frisby.create('DELETE - should throw an error (id valid but not found in the DB)')

--- a/server-tests/tests-frisby_spec.js
+++ b/server-tests/tests-frisby_spec.js
@@ -203,7 +203,7 @@ frisby.create('CREATE - should create an object in the database')
     //it always return a non empty array
     frisby.create('GRAPH - should throw an error (id empty) - Not found')
         .get(url + 'graph/')
-        .expectStatus(400)
+        .expectStatus(404)
     .toss();
 
     frisby.create('GRAPH - should throw an error (id not found) - Not found')


### PR DESCRIPTION
With this update:

- `graph` and `delete` are now possible via `POST` requests, exactly like the `read` method.
- `update` now supports putting the ids inside of the request body, and also providing multiple update objects in a single request:
```json
[{ "_id": ["/home/gnoxr/test.md", "303948"],
  "keyToInsert": "value",
  "keyToRemove": null
},
 { "_id": "jean",
  "age": "38"
}]
```
- The `_id` key is autodetected and replaced with a `file` key for the functions needing it. A large part of the search queries are done only to get the ID of an element based on its known `file` key. This way, we can avoid these queries by providing directly the file name as an id.

However, we need to update the MongoDB database in order to make an unique index of the `file` key when provided:
```javascript
db.node.createIndex({"file": 1}, {unique: true, partialFilterExpression: {file: {$exists: true}}})
```
The nodes already created using a file name as their ID must also be updated (to move or at least copy this ID inside of their `file` attribute).

Apart from this, everything is still retro-compatible, and nothing should be broken by this update. The clients do not need to be changed, as all of these operations (plus some verifications) are done server-side.
Thus, this update solves the issues #120, #78, and is a possible solution to the #95.