### PR TITLE
Fix #95 (custom node indexes)

### DIFF
--- a/js/damas.js
+++ b/js/damas.js
@@ -187,7 +187,8 @@
             return false;
         }
         var req = new XMLHttpRequest();
-        req.open('PUT', this.server + "update/" + id, callback !== undefined);
+        req.open('PUT', this.server + "update/" + encodeURIComponent(id),
+            callback !== undefined);
         req.setRequestHeader("Content-type","application/json");
         req.setRequestHeader("Accept","application/json");
         req.setRequestHeader("Authorization","Bearer "+damas.token);
@@ -222,7 +223,8 @@
             return false;
         }
         var req = new XMLHttpRequest();
-        req.open('DELETE', this.server + "delete/" + id, callback !== undefined);
+        req.open('DELETE', this.server + "delete/" + encodeURIComponent(id),
+            callback !== undefined);
         //req.setRequestHeader("Content-type","application/x-www-form-urlencoded");
         req.setRequestHeader("Authorization","Bearer "+damas.token);
         req.onreadystatechange = function(e) {
@@ -255,7 +257,8 @@
             return false;
         }
         var req = new XMLHttpRequest();
-        req.open('GET', this.server + 'search/' + encodeURIComponent(query), callback !== undefined);
+        req.open('GET', this.server + 'search/' + encodeURIComponent(query),
+            callback !== undefined);
         req.setRequestHeader("Authorization","Bearer "+damas.token);
         req.onreadystatechange = function(e) {
             if (req.readyState == 4) {
@@ -279,7 +282,8 @@
             return false;
         }
         var req = new XMLHttpRequest();
-        req.open('GET', this.server + 'search_one/' + encodeURIComponent(query), callback !== undefined);
+        req.open('GET', this.server + 'search_one/' + encodeURIComponent(query),
+            callback !== undefined);
         req.setRequestHeader("Authorization","Bearer "+damas.token);
         req.onreadystatechange = function(e) {
             if (req.readyState == 4) {
@@ -379,7 +383,8 @@
             return false;
         }
         var req = new XMLHttpRequest();
-        req.open('GET', this.server + 'graph/' + encodeURIComponent(ids), callback !== undefined);
+        req.open('GET', this.server + 'graph/' + encodeURIComponent(ids),
+            callback !== undefined);
         req.setRequestHeader("Authorization","Bearer "+damas.token);
         req.onreadystatechange = function(e) {
             if (req.readyState == 4) {
@@ -412,7 +417,8 @@
             return req.status === 200;
         }
         var req = new XMLHttpRequest();
-        req.open('PUT', this.server+'lock/'+id, callback !== undefined);
+        req.open('PUT', this.server+'lock/' + encodeURIComponent(id),
+            callback !== undefined);
         req.setRequestHeader("Content-type","application/json");
         req.setRequestHeader("Accept","application/json");
         req.setRequestHeader("Authorization","Bearer "+damas.token);
@@ -434,7 +440,8 @@
             return req.status === 200;
         }
         var req = new XMLHttpRequest();
-        req.open('PUT', this.server+'unlock/'+id, callback !== undefined);
+        req.open('PUT', this.server+'unlock/' + encodeURIComponent(id),
+            callback !== undefined);
         req.setRequestHeader("Content-type","application/json");
         req.setRequestHeader("Accept","application/json");
         req.setRequestHeader("Authorization","Bearer "+damas.token);
@@ -472,7 +479,8 @@
             return false;
         }
         var req = new XMLHttpRequest();
-        req.open('POST', this.server+'version/'+id, callback !== undefined);
+        req.open('POST', this.server+'version/' + encodeURIComponent(id),
+            callback !== undefined);
         req.setRequestHeader("Content-type","application/x-www-form-urlencoded");
         req.setRequestHeader("Authorization","Bearer "+damas.token);
         req.onreadystatechange = function(e) {

--- a/js/damas.js
+++ b/js/damas.js
@@ -1,19 +1,17 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(function () {
-            return (root.returnExportsGlobal = factory());
-        });
+        define(['xmlhttprequest'], factory);
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.
-        module.exports = factory();
+        module.exports = factory(require('xmlhttprequest').XMLHttpRequest);
     } else {
         // Browser globals
-        root.damas = factory();
+        root.damas = factory(root.XMLHttpRequest);
     }
-}(this, function () {
+}(this, function (XHR) {
 
     /**
      * DAMAS HTTP client module for Javascript.
@@ -56,6 +54,53 @@
     damas.token = null;
     damas.user = null;
 
+
+    function req(args) {
+        if (args.async === undefined) {
+            args.async = ('function' === typeof args.callback);
+        }
+        function checkXHR(xhr) {
+            if (xhr.status < 300) {
+                return JSON.parse(xhr.responseText);
+            } else {
+                console.warn(xhr.responseText);
+                return false;
+            }
+        }
+        var xhr = new XHR();
+        xhr.open(args.method, damas.server + args.url, args.async);
+        xhr.setRequestHeader('Authorization', 'Bearer ' + damas.token);
+        if (undefined === args.data) {
+            xhr.send();
+        } else {
+            var data = JSON.stringify(args.data);
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.send(data);
+        }
+        if (!args.async) {
+            return checkXHR(xhr);
+        }
+        xhr.onreadystatechange = function(e) {
+            if (xhr.readyState == 4) {
+                args.callback(checkXHR(xhr));
+            }
+        }
+    }
+
+    var sep = '<sep>';
+    function toURI(ids) {
+        if (!Array.isArray(ids)) {
+            if ('string' === typeof ids) {
+                ids = ids.split(',');
+            } else {
+                return null;
+            }
+        }
+        var abc = ids.map(encodeURIComponent).join(sep);
+        console.log(abc);
+        return abc;
+    }
+
     //
     //
     //
@@ -70,7 +115,7 @@
      * This callback type `requestCallback` to handle asynchronous requests results
      *
      * @callback requestCallback
-     * @param {object} req - XMLHttpRequest object
+     * @param {object} req - XHR object
      *
      */
 
@@ -88,35 +133,12 @@
      * var newNode= damas.create(keys);
      */
     damas.create = function (keys, callback) {
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('POST', this.server + "create/", callback !== undefined);
-        req.setRequestHeader("Content-type","application/json");
-        //req.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send(JSON.stringify(keys));
-        /*
-        var qs = Object.keys(keys).map(function(key) {
-            return encodeURIComponent(key) + '=' + encodeURIComponent(keys[key]);
-        }).join('&');
-        req.send(qs);
-        */
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'POST',
+            url: 'create/',
+            data: keys,
+            callback: callback
+        });
     }
 
     /**
@@ -138,32 +160,17 @@
         if (Array.isArray(id) && id.length === 0) {
             return callback([]);
         }
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('POST', this.server + "read/", callback !== undefined);
-        req.setRequestHeader("Content-type","application/json");
-        req.setRequestHeader("Authorization","Bearer " + damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send(JSON.stringify(id));
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'POST',
+            url: 'read/',
+            data: id,
+            callback: callback
+        });
     }
 
     /**
-     * Update the keys of a node. The specified keys overwrite existing keys, others are left untouched. A null key value removes the key.
+     * Update the keys of a node. The specified keys overwrite existing keys,
+     * others are left untouched. A null key value removes the key.
      * @param {string} id - Internal index of the node to update
      * @param {object} keys - Hash of key:value pairs
      * @returns {object|undefined} Node or nothing in case of asynchronous call
@@ -175,34 +182,13 @@
      * //Update the node id with this set of keys
      * var node= damas.update(id, keys);
      */
-    damas.update = function (id, keys, callback) {
-        if (Array.isArray(id)) {
-            id = id.join('<sep>');
-        }
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('PUT', this.server + "update/" + encodeURIComponent(id),
-            callback !== undefined);
-        req.setRequestHeader("Content-type","application/json");
-        req.setRequestHeader("Accept","application/json");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState === 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send(JSON.stringify(keys));
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+    damas.update = function (id, node, callback) {
+        return req({
+            method: 'PUT',
+            url: 'update/' + toURI(id),
+            data: node,
+            callback: callback
+        });
     }
 
     /**
@@ -215,29 +201,12 @@
      * damas.delete(id);
      */
     damas.delete = function (id, callback) {
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('DELETE', this.server + "delete/" + encodeURIComponent(id),
-            callback !== undefined);
-        //req.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send();
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'DELETE',
+            url: 'delete/',
+            data: id,
+            callback: callback
+        });
     }
 
     /**
@@ -249,54 +218,20 @@
      * var matches = damas.search('rabbit type:char');
      */
     damas.search = function (query, callback) {
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('GET', this.server + 'search/' + encodeURIComponent(query),
-            callback !== undefined);
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send();
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'GET',
+            url: 'search/' + encodeURIComponent(query),
+            callback: callback
+        });
     }
 
     damas.search_one = function (query, callback) {
-         function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('GET', this.server + 'search_one/' + encodeURIComponent(query),
-            callback !== undefined);
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send();
-        if (callback === undefined) {
-            return req_callback(req);
-        }
-   }
+        return req({
+            method: 'GET',
+            url: 'search_one/' + encodeURIComponent(query),
+            callback: callback
+        });
+    }
 
     /**
      * BETA - Expose the find method from mongodb
@@ -306,7 +241,8 @@
      * @param {Integer} skip
      * @returns {Array} array of element indexes or null if no element found
      *
-     * query, sort, limit, skip arguments are respectively passed to mongodb methods of the same names.
+     * query, sort, limit, skip arguments are respectively passed to mongodb
+     * methods of the same names.
      * https://docs.mongodb.org/manual/reference/method/db.collection.find/
      * because the query object is converted to JSON, we use strings with "REGEX_" as suffix to define regular expressions. for example, /.*x$/ will be defined as "REGEX_.*x$" 
      *
@@ -314,33 +250,18 @@
      * damas.search_mongo({"lock": /.*$/}, {"lock":1}, 2,0)
      */
     damas.search_mongo = function (query, sort, limit, skip, callback) {
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
+        var obj = {
+            query: query,
+            sort: sort,
+            limit: limit,
+            skip: skip
         }
-        var req = new XMLHttpRequest();
-        req.open('POST', this.server+"search_mongo", callback !== undefined);
-        req.setRequestHeader("Content-type","application/json");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        var obj = {};
-        obj.query = query;
-        obj.sort = sort;
-        obj.limit = limit;
-        obj.skip = skip;
-        req.send(JSON.stringify(obj));
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'POST',
+            url: 'search_mongo',
+            data: obj,
+            callback: callback
+        });
     }
 
 
@@ -375,91 +296,54 @@
      * var sources = damas.graph("55687e68e040af7047ee1a53");
      */
     damas.graph = function (ids, callback) {
-        function req_callback(req) {
-            if (300 > req.status) {
-                return JSON.parse(req.responseText);
-            }
-            console.log(req.responseText);
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('GET', this.server + 'graph/' + encodeURIComponent(ids),
-            callback !== undefined);
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send();
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'POST',
+            url: 'graph/',
+            data: ids,
+            callback: callback
+        });
     }
 
+    // FIXME legacy?
     damas.get_rest = function (query, callback) {
-        var req = new XMLHttpRequest();
-        req.open('GET', this.server + query, callback !== undefined);
-        //req.open('GET', this.server + encodeURIComponent(query), callback !== undefined);
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                callback(300 > req.status ? JSON.parse(req.responseText) : false);
-            }
-        }
-        req.send();
+        return req({
+            method: 'GET',
+            url: query,
+            callback: callback
+        });
     }
 
     damas.lock = function (id, callback) {
-        function req_callback(req) {
-            return req.status === 200;
-        }
-        var req = new XMLHttpRequest();
-        req.open('PUT', this.server+'lock/' + encodeURIComponent(id),
-            callback !== undefined);
-        req.setRequestHeader("Content-type","application/json");
-        req.setRequestHeader("Accept","application/json");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState === 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
+        var res = req({
+            method: 'PUT',
+            url: 'lock/' + toURI(id),
+            async: callback !== undefined,
+            callback: function (res) {
+                callback(res !== false);
             }
-        }
-        req.send();
-        if (callback === undefined) {
-            return req_callback(req);
+        });
+        if (undefined !== res) {
+            return res !== false;
         }
     }
 
     damas.unlock = function (id, callback) {
-        function req_callback(req) {
-            return req.status === 200;
-        }
-        var req = new XMLHttpRequest();
-        req.open('PUT', this.server+'unlock/' + encodeURIComponent(id),
-            callback !== undefined);
-        req.setRequestHeader("Content-type","application/json");
-        req.setRequestHeader("Accept","application/json");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState === 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
+        var res = req({
+            method: 'PUT',
+            url: 'unlock/' + toURI(id),
+            async: callback !== undefined,
+            callback: function (res) {
+                callback(res !== false);
             }
-        }
-        req.send();
-        if (callback === undefined) {
-            return req_callback(req);
+        });
+        if (undefined !== res) {
+            return res !== false;
         }
     }
 
     /**
-     * Creates a node with the specified keys, asynchronously if a callback function is specified or synchronously otherwise.
+     * Creates a node with the specified keys, asynchronously if a callback
+     * function is specified or synchronously otherwise.
      * @param {hash} keys - Hash of key:value pairs
      * @param {function} [callback] - Function with the XHR object as argument to call
      * @returns {object|boolean|undefined} New node on success, false otherwise (or nothing if async)
@@ -472,31 +356,12 @@
      * var newNode= damas.create(keys);
      */
     damas.version = function (id, keys, callback) {
-        function req_callback(req) {
-            if (req.status === 201) {
-                return JSON.parse(req.responseText);
-            }
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('POST', this.server+'version/' + encodeURIComponent(id),
-            callback !== undefined);
-        req.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        var qs = Object.keys(keys).map(function(key) {
-            return encodeURIComponent(key) + '=' + encodeURIComponent(keys[key]);
-        }).join('&');
-        req.send(qs);
-        if (callback === undefined) {
-            return req_callback(req);
-        }
+        return req({
+            method: 'POST',
+            url: 'version/' + id,
+            data: keys,
+            callback: callback
+        });
     }
 
     //
@@ -516,27 +381,26 @@
      * @return true on success, false otherwise
      */
     damas.signIn = function (username, password, callback) {
-        function req_callback(req) {
-            if (req.status === 200) {
+        function req_callback(res) {
+            if (res !== false) {
                 damas.user = JSON.parse(req.responseText);
                 damas.token = damas.user.token;
-                return JSON.parse(req.responseText);
-            }
-            return false;
-        }
-        var req = new XMLHttpRequest();
-        req.open('POST', this.server+"signIn", callback !== undefined);
-        req.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
+                callback(JSON.parse(res));
+            } else {
+                callback(false);
             }
         }
-        req.send("username="+encodeURIComponent(username) + "&password="+encodeURIComponent(password));
-        if (callback === undefined) {
-            return req_callback(req);
+        var res = req({
+            method: 'POST',
+            url: 'signIn',
+            headers: { 'Content-type': 'application/x-www-form-urlencoded' },
+            data: "username="+encodeURIComponent(username) + "&password="+encodeURIComponent(password),
+            callback: function (res) {
+                callback(req_callback(res));
+            }
+        });
+        if (undefined !== res) {
+            return req_callback(res);
         }
     }
 
@@ -557,23 +421,17 @@
      * @return true on success, false otherwise
      */
     damas.verify = function (callback) {
-        function req_callback(req) {
-            if (req.status === 200) {
-                return true;
+        var res = req({
+            method: 'GET',
+            url: 'verify',
+            async: callback !== undefined,
+            callback: function (res) {
+                callback(res !== false);
             }
-            return false;
+        });
+        if (undefined !== res) {
+            return res !== false;
         }
-        var req = new XMLHttpRequest();
-        req.open('GET', this.server+"verify", callback !== undefined);
-        req.setRequestHeader("Authorization","Bearer "+damas.token);
-        req.onreadystatechange = function(e) {
-            if (req.readyState == 4) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
-            }
-        }
-        req.send();
     }
 
 

--- a/js/damas.js
+++ b/js/damas.js
@@ -177,7 +177,7 @@
      */
     damas.update = function (id, keys, callback) {
         if (Array.isArray(id)) {
-            id = id.join(',');
+            id = id.join('<sep>');
         }
         function req_callback(req) {
             if (300 > req.status) {

--- a/py/damas.py
+++ b/py/damas.py
@@ -25,6 +25,7 @@
 
 import json
 import requests
+import urllib
 
 #requests.packages.urllib3.disable_warnings() # remove certificate warning
 
@@ -46,7 +47,8 @@ class http_connection( object ) :
 		'''
 		headers = {'content-type': 'application/json'}
 		headers.update(self.headers)
-		r = requests.post(self.serverURL+"/create/", data=json.dumps(keys), headers=headers, verify=False)
+		r = requests.post(self.serverURL+"/create/", data=json.dumps(keys),
+			headers=headers, verify=False)
 		if r.status_code == 201 or r.status_code == 207:
 			return json.loads(r.text)
 		return None
@@ -59,7 +61,8 @@ class http_connection( object ) :
 		'''
 		headers = {'content-type': 'application/json'}
 		headers.update(self.headers)
-		r = requests.post(self.serverURL+"/read/", data=json.dumps(id_), headers=headers, verify=False)
+		r = requests.post(self.serverURL+"/read/", data=json.dumps(id_),
+			headers=headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
 			return json.loads(r.text)
 		return None
@@ -77,7 +80,8 @@ class http_connection( object ) :
 			id_ = ",".join(id_)
 		headers = {'content-type': 'application/json'}
 		headers.update(self.headers)
-		r = requests.put(self.serverURL+'/update/'+id_, data=json.dumps(keys), headers=headers, verify=False)
+		r = requests.put(self.serverURL+'/update/'+urllib.quote(id_, safe=''),
+			data=json.dumps(keys), headers=headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
 			return json.loads(r.text)
 		return None
@@ -90,7 +94,8 @@ class http_connection( object ) :
 		'''
 		if isinstance(id_, (tuple,list,set)):
 			id_ = ",".join(id_)
-		r = requests.delete(self.serverURL+'/delete/'+id_, headers=self.headers, verify=False)
+		r = requests.delete(self.serverURL+'/delete/'+urllib.quote(id_, safe=''),
+			headers=self.headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
 			return json.loads(r.text)
 		return None
@@ -101,7 +106,8 @@ class http_connection( object ) :
 		@param {String} query string
 		@returns {Array} array of element indexes or None if no element found
 		'''
-		r = requests.get(self.serverURL+'/search/'+query, headers=self.headers, verify=False)
+		r = requests.get(self.serverURL+'/search/'+urllib.quote(query, safe=''),
+			headers=self.headers, verify=False)
 		if r.status_code == 200:
 			return json.loads(r.text)
 		return None
@@ -109,11 +115,12 @@ class http_connection( object ) :
 	def search_one( self, query ) :
 		'''
 		Find nodes wearing the specified key(s) and return the first
-                occurence found
+				occurence found
 		@param {String} query string
 		@returns {Array} array of element indexes or None if no element found
 		'''
-		r = requests.get(self.serverURL+'/search_one/'+query, headers=self.headers, verify=False)
+		r = requests.get(self.serverURL+'/search_one/'+
+			urllib.quote(query, safe=''), headers=self.headers, verify=False)
 		if r.status_code == 200:
 			return json.loads(r.text)
 		return None
@@ -122,7 +129,8 @@ class http_connection( object ) :
 		data = {"query":query, "sort":sort, "limit":limit, "skip":skip}
 		headers = {'content-type': 'application/json'}
 		headers.update(self.headers)
-		r = requests.post(self.serverURL+'/search_mongo', data=json.dumps(data), headers=headers, verify=False)
+		r = requests.post(self.serverURL+'/search_mongo', data=json.dumps(data),
+			headers=headers, verify=False)
 		if r.status_code == 200:
 			return json.loads(r.text)
 		return None
@@ -135,7 +143,8 @@ class http_connection( object ) :
 		'''
 		if isinstance(id_, (tuple,list,set)):
 			id_ = ",".join(id_)
-		r = requests.get(self.serverURL+'/graph/'+id_, headers=self.headers, verify=False)
+		r = requests.get(self.serverURL+'/graph/'+urllib.quote(id_, safe=''),
+			headers=self.headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
 			return json.loads(r.text)
 		return None
@@ -146,7 +155,8 @@ class http_connection( object ) :
 		@param {String} id_ the internal node index
 		@returns {Boolean} True on success, False otherwise
 		'''
-		r = requests.put(self.serverURL+'/lock/'+id_, headers=self.headers, verify=False)
+		r = requests.put(self.serverURL+'/lock/'+urllib.quote(id_, safe=''),
+			headers=self.headers, verify=False)
 		return r.status_code == 200
 
 	def unlock( self, id_ ) :
@@ -155,7 +165,8 @@ class http_connection( object ) :
 		@param {String} id_ the internal node index
 		@returns {Boolean} True on success, False otherwise
 		'''
-		r = requests.put(self.serverURL+'/unlock/'+id_, headers=self.headers, verify=False)
+		r = requests.put(self.serverURL+'/unlock/'+urllib.quote(id_, safe=''),
+			headers=self.headers, verify=False)
 		return r.status_code == 200
 
 	def version( self, id_, keys ) :
@@ -166,7 +177,8 @@ class http_connection( object ) :
 		'''
 		headers = {'content-type': 'application/json'}
 		headers.update(self.headers)
-		r = requests.post('%s/version/%s' % (self.serverURL, id_), data=json.dumps(keys), headers=headers, verify=False)
+		r = requests.post('%s/version/%s' % (self.serverURL, id_),
+			data=json.dumps(keys), headers=headers, verify=False)
 		if r.status_code == 201:
 			return json.loads(r.text)
 		return None
@@ -194,7 +206,8 @@ class http_connection( object ) :
 		'''
 		@return {Boolean} True on success, False otherwise
 		'''
-		r = requests.post(self.serverURL+'/signIn', data={"username":username, "password":password}, verify=False)
+		r = requests.post(self.serverURL+'/signIn', data={"username":username,
+			"password":password}, verify=False)
 		if r.status_code == 200:
 			self.token = json.loads(r.text)
 			self.headers['Authorization'] = 'Bearer ' + self.token['token']
@@ -217,7 +230,8 @@ class http_connection( object ) :
 		'''
 		@return {dict} a dictionary containing username and userclass on success, None otherwise
 		'''
-		r = requests.get(self.serverURL+'/verify', headers=self.headers, verify=False )
+		r = requests.get(self.serverURL+'/verify', headers=self.headers,
+			verify=False )
 		if r.status_code == 200:
 			return True
 		return False

--- a/py/damas.py
+++ b/py/damas.py
@@ -30,6 +30,8 @@ import urllib
 #requests.packages.urllib3.disable_warnings() # remove certificate warning
 
 class http_connection( object ) :
+	__sep = '<sep>'
+
 	'''
 	Methods to interact with a remote DAMAS server using HTTP
 	'''
@@ -45,7 +47,7 @@ class http_connection( object ) :
 		@param {Hash} keys of the new node
 		@returns {Hash} New node on success, false otherwise
 		'''
-		headers = {'content-type': 'application/json'}
+		headers = {'Content-Type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.post(self.serverURL+"/create/", data=json.dumps(keys),
 			headers=headers, verify=False)
@@ -59,7 +61,7 @@ class http_connection( object ) :
 		@param {String} id_ the internal node index to search
 		@returns {Hash} node or false on failure
 		'''
-		headers = {'content-type': 'application/json'}
+		headers = {'Content-Type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.post(self.serverURL+"/read/", data=json.dumps(id_),
 			headers=headers, verify=False)
@@ -77,8 +79,8 @@ class http_connection( object ) :
 		@returns {Hash} updated node or false on failure
 		'''
 		if isinstance(id_, (tuple,list,set)):
-			id_ = "<sep>".join(id_)
-		headers = {'content-type': 'application/json'}
+			id_ = __sep.join(id_)
+		headers = {'Content-Type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.put(self.serverURL+'/update/'+urllib.quote(id_, safe=''),
 			data=json.dumps(keys), headers=headers, verify=False)
@@ -93,7 +95,7 @@ class http_connection( object ) :
 		@returns {Boolean} True on success, False otherwise
 		'''
 		if isinstance(id_, (tuple,list,set)):
-			id_ = "<sep>".join(id_)
+			id_ = __sep.join(id_)
 		r = requests.delete(self.serverURL+'/delete/'+urllib.quote(id_, safe=''),
 			headers=self.headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
@@ -114,8 +116,7 @@ class http_connection( object ) :
 
 	def search_one( self, query ) :
 		'''
-		Find nodes wearing the specified key(s) and return the first
-				occurence found
+		Find nodes wearing the specified key(s) and return the first occurence
 		@param {String} query string
 		@returns {Array} array of element indexes or None if no element found
 		'''
@@ -127,7 +128,7 @@ class http_connection( object ) :
 
 	def search_mongo( self, query, sort, limit, skip ) :
 		data = {"query":query, "sort":sort, "limit":limit, "skip":skip}
-		headers = {'content-type': 'application/json'}
+		headers = {'Content-Type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.post(self.serverURL+'/search_mongo', data=json.dumps(data),
 			headers=headers, verify=False)
@@ -142,7 +143,7 @@ class http_connection( object ) :
 		@returns {Hash} node or false on failure
 		'''
 		if isinstance(id_, (tuple,list,set)):
-			id_ = "<sep>".join(id_)
+			id_ = __sep.join(id_)
 		r = requests.get(self.serverURL+'/graph/'+urllib.quote(id_, safe=''),
 			headers=self.headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
@@ -175,7 +176,7 @@ class http_connection( object ) :
 		@param {Hash} keys of the new node
 		@returns {Hash} New node on success, false otherwise
 		'''
-		headers = {'content-type': 'application/json'}
+		headers = {'Content-Type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.post('%s/version/%s' % (self.serverURL, id_),
 			data=json.dumps(keys), headers=headers, verify=False)
@@ -191,7 +192,7 @@ class http_connection( object ) :
 		@returns {Hash} Array of created edges ids on success, None otherwise
 		'''
 		data = {"target":target, "sources":sources, "keys":keys}
-		headers = {'content-type': 'application/json'}
+		headers = {'Content-Type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.post('%s/link' % (self.serverURL), data=json.dumps(data), headers=headers, verify=False)
 		if r.status_code == 200:

--- a/py/damas.py
+++ b/py/damas.py
@@ -77,7 +77,7 @@ class http_connection( object ) :
 		@returns {Hash} updated node or false on failure
 		'''
 		if isinstance(id_, (tuple,list,set)):
-			id_ = ",".join(id_)
+			id_ = "<sep>".join(id_)
 		headers = {'content-type': 'application/json'}
 		headers.update(self.headers)
 		r = requests.put(self.serverURL+'/update/'+urllib.quote(id_, safe=''),
@@ -93,7 +93,7 @@ class http_connection( object ) :
 		@returns {Boolean} True on success, False otherwise
 		'''
 		if isinstance(id_, (tuple,list,set)):
-			id_ = ",".join(id_)
+			id_ = "<sep>".join(id_)
 		r = requests.delete(self.serverURL+'/delete/'+urllib.quote(id_, safe=''),
 			headers=self.headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:
@@ -142,7 +142,7 @@ class http_connection( object ) :
 		@returns {Hash} node or false on failure
 		'''
 		if isinstance(id_, (tuple,list,set)):
-			id_ = ",".join(id_)
+			id_ = "<sep>".join(id_)
 		r = requests.get(self.serverURL+'/graph/'+urllib.quote(id_, safe=''),
 			headers=self.headers, verify=False)
 		if r.status_code == 200 or r.status_code == 207:

--- a/server-nodejs/routes/cruds.js
+++ b/server-nodejs/routes/cruds.js
@@ -8,7 +8,24 @@ module.exports = function (app, express) {
     //methodOverride = require('method-override'),
     var fs = require('fs');
     var events = require('../events');
+    var sep = '<sep>';
 
+    function getRequestIds(req, isArrayCallback) {
+        if (req.params.id) {
+            var ids = req.params.id.split(sep);
+            var isArray = (ids.length > 1);
+        } else if (req.body) {
+            var isArray = Array.isArray(req.body);
+            var ids = isArray ? req.body : [req.body];
+        }
+        if (!ids || ids.some(elem => typeof elem !== 'string')) {
+            return false;
+        }
+        if ('function' === typeof isArrayCallback) {
+            isArrayCallback(isArray);
+        }
+        return ids;
+    }
 /*
     app.use(methodOverride(function (req, res) {
         if (req.body && typeof req.body === 'object' && '_method' in req.body) {
@@ -102,19 +119,12 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     read = function (req, res) {
-        if (req.params.id) {
-            var ids = req.params.id.split('<sep>');
-            var isArray = ids.length > 1;
-        } else if (req.body) {
-            var ids = req.body;
-            var isArray = Array.isArray(ids);
-            if (!isArray) {
-                ids = [ids];
-            }
-        } else {
-            httpStatus(res, 400, 'read');
-            return;
+        var isArray = false;
+        var ids = getRequestIds(req, function (isIt) { isArray = isIt; });
+        if (!ids) {
+            return httpStatus(res, 400, 'Read');
         }
+
         db.read(ids, function (error, doc) {
             if (error) {
                 httpStatus(res, 409, 'read');
@@ -147,12 +157,12 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     update = function (req, res) {
-        if (Object.keys(req.body).length === 0) {
+        if (Object.keys(req.body).length === 0 || !req.params.id) {
             httpStatus(res, 400, 'update');
             return;
         }
 
-        var ids = req.params.id.split('<sep>');
+        var ids = req.params.id.split(sep);
         var body = req.body;
         events.fire('pre-update', ids, body).then(function (data) {
             if (data.status) {
@@ -194,7 +204,11 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     deleteNode = function (req, res) {
-        var ids = req.params.id.split('<sep>');
+        var ids = getRequestIds(req);
+        if (!ids) {
+            return httpStatus(res, 400, 'Remove');
+        }
+
         events.fire('pre-remove', ids).then(function (data) {
             if (data.status) {
                 httpStatus(res, data.status, 'remove');
@@ -208,7 +222,7 @@ module.exports = function (app, express) {
                 } else if (response.partial) {
                     httpStatus(res, 207, doc);
                 } else {
-                    httpStatus(res, 200, 1 < ids.length ? doc : doc[0]);
+                    httpStatus(res, 200, 1 === doc.length ? doc[0] : doc);
                 }
             });
         });
@@ -230,12 +244,12 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     graph = function (req, res) {
-        var id = req.params.id || req.body.id;
-        if (!id || id == 'undefined') {
-            httpStatus(res, 400, 'graph');
-            return;
+        var ids = getRequestIds(req);
+        if (!ids) {
+            return httpStatus(res, 400, 'Graph');
         }
-        db.graph(id.split('<sep>'), function (error, nodes) {
+
+        db.graph(ids, function (error, nodes) {
             if (error) {
                 httpStatus(res, 409, 'graph');
                 return;
@@ -246,7 +260,8 @@ module.exports = function (app, express) {
             } else if (response.partial) {
                 httpStatus(res, 207, nodes);
             } else {
-                httpStatus(res, 200, true ? nodes : nodes[0]); // FIXME
+                // We never need a single element
+                httpStatus(res, 200, nodes);
             }
         });
     }; // graph()
@@ -452,11 +467,9 @@ module.exports = function (app, express) {
 
 
     /**
-     * Sets the appropriate response and status code for multiple params or not
-     * @param {boolean} isArray - did client sent an array or not
+     * Tells whether a response is failed or incomplete (contains null?)
      * @param {array} doc - the database response
-     * @param {} result - the returned object or string
-     * @return {{status: number, content: result}} - the results to send
+     * @return {{fail: boolean, partial: boolean}} - the results to send
      */
     function getMultipleResponse(doc) {
         var result = { fail: true, partial: false };
@@ -499,12 +512,15 @@ module.exports = function (app, express) {
     app.post('/api/read/', read);
     app.put('/api/update/:id', update);
     app.delete('/api/delete/:id', deleteNode);
+    app.delete('/api/delete/', deleteNode);
 
     // Search operations
     app.get('/api/search/:query(*)', search);
     app.get('/api/search_one/:query(*)', search_one);
     app.post('/api/search_mongo', search_mongo);
-    app.get('/api/graph/', graph);
+    app.get('/api/graph/', graph); // Fix
+    app.get('/api/graph/:id', graph);
+    app.post('/api/graph/', graph);
 
     // CRUD operations (deprecated)
     app.post('/api/', create);
@@ -513,7 +529,6 @@ module.exports = function (app, express) {
     app.delete('/api/:id', deleteNode);
 
     // Extra operations
-    app.get('/api/graph/:id', graph);
     app.get('/api/file/:path(*)', getFile); // untested
     app.post('/api/import', importJSON); // untested
     //app.get('/subdirs/:path', getSubdirs);

--- a/server-nodejs/routes/cruds.js
+++ b/server-nodejs/routes/cruds.js
@@ -103,7 +103,7 @@ module.exports = function (app, express) {
      */
     read = function (req, res) {
         if (req.params.id) {
-            var ids = req.params.id.split(',');
+            var ids = req.params.id.split('<sep>');
             var isArray = ids.length > 1;
         } else if (req.body) {
             var ids = req.body;
@@ -152,7 +152,7 @@ module.exports = function (app, express) {
             return;
         }
 
-        var ids = req.params.id.split(',');
+        var ids = req.params.id.split('<sep>');
         var body = req.body;
         events.fire('pre-update', ids, body).then(function (data) {
             if (data.status) {
@@ -194,7 +194,7 @@ module.exports = function (app, express) {
      * - 404: Not Found (all the nodes do not exist)
      */
     deleteNode = function (req, res) {
-        var ids = req.params.id.split(',');
+        var ids = req.params.id.split('<sep>');
         events.fire('pre-remove', ids).then(function (data) {
             if (data.status) {
                 httpStatus(res, data.status, 'remove');
@@ -235,7 +235,7 @@ module.exports = function (app, express) {
             httpStatus(res, 400, 'graph');
             return;
         }
-        db.graph(id.split(','), function (error, nodes) {
+        db.graph(id.split('<sep>'), function (error, nodes) {
             if (error) {
                 httpStatus(res, 409, 'graph');
                 return;

--- a/server-nodejs/routes/dam.js
+++ b/server-nodejs/routes/dam.js
@@ -5,7 +5,24 @@
 
 module.exports = function (app) {
     var db = app.locals.db;
+    var sep = '<sep>';
 
+    function getRequestIds(req, isArrayCallback) {
+        if (req.params.id) {
+            var ids = req.params.id.split(sep);
+            var isArray = (ids.length > 1);
+        } else if (req.body) {
+            var isArray = Array.isArray(req.body);
+            var ids = isArray ? req.body : [req.body];
+        }
+        if (!ids || ids.some(elem => typeof elem !== 'string')) {
+            return false;
+        }
+        if ('function' === typeof isArrayCallback) {
+            isArrayCallback(isArray);
+        }
+        return ids;
+    }
 
     /*
      * Method: PUT
@@ -28,7 +45,7 @@ module.exports = function (app) {
             return;
         }
         */
-        var n = db.read([req.params.id], function (err, n) {
+        var n = db.read(getRequestIds(req), function (err, n) {
             if (n[0].lock !== undefined) {
                 res.status(409);
                 res.send('lock error, the asset is already locked');
@@ -37,14 +54,14 @@ module.exports = function (app) {
             var keys = {
                 "lock": req.user.username || req.connection.remoteAddress
             };
-            db.update([req.params.id], keys, function (error, doc) {
+            db.update(getRequestIds(req), keys, function (error, doc) {
                 if (error) {
                     res.status(409);
                     res.send('lock error, please change your values');
                     return;
                 }
                 res.status(200);
-                res.send('asset locked');
+                res.json(doc[0]);
             });
         });
     });
@@ -70,21 +87,21 @@ module.exports = function (app) {
             return;
         }
         */
-        var n = db.read([req.params.id], function (err, n) {
+        var n = db.read(getRequestIds(req), function (err, n) {
             var user = req.user.username || req.connection.remoteAddress;
             if (n[0].lock !== user) {
                 res.status(409);
                 res.send('lock error, the asset is locked by '+ n[0].lock);
                 return;
             }
-            db.update([req.params.id], {"lock": null}, function (error, doc) {
+            db.update(getRequestIds(req), {"lock": null}, function (error, doc) {
                 if (error) {
                     res.status(409);
                     res.send('lock error, please change your values');
                     return;
                 }
                 res.status(200);
-                res.send('asset unlocked');
+                res.send(doc[0]);
             });
         });
     });

--- a/server-tests/tests-frisby_spec.js
+++ b/server-tests/tests-frisby_spec.js
@@ -113,7 +113,7 @@ frisby.create('CREATE - should create an object in the database')
     .toss();
 
     frisby.create('READ - should get 2 records valid - GET')
-        .get(url + 'read/' + idFoundInDb + ',' + idCustomEncoded)
+        .get(url + 'read/' + idFoundInDb + '<sep>' + idCustomEncoded)
         .expectStatus(200)
         .expectHeaderContains('Content-Type', tjson)
         .expectJSONTypes({
@@ -190,7 +190,7 @@ frisby.create('CREATE - should create an object in the database')
 
     frisby.create('UPDATE - should update 2 documents')
         .addHeader('Content-Type', tjson)
-        .put(url + 'update/' + idFoundInDb + ',' + idCustomEncoded, {'c':'d'},
+        .put(url + 'update/' + idFoundInDb + '<sep>' + idCustomEncoded, {'c':'d'},
             asJSON)
         .expectHeaderContains('Content-Type', tjson)
         .expectJSONTypes('*', {'c':'d'})
@@ -229,7 +229,7 @@ frisby.create('CREATE - should create an object in the database')
     .toss();
 
     frisby.create('GRAPH - should get 2 records valid')
-        .get(url + 'graph/' + idFoundInDb + ',' + idCustomEncoded)
+        .get(url + 'graph/' + idFoundInDb + '<sep>' + idCustomEncoded)
         .expectStatus(200)
         .expectHeaderContains('Content-Type', tjson)
         .expectJSONTypes({
@@ -349,7 +349,7 @@ frisby.create('CREATE - should create an object in the database')
         idFoundInDb = res[0]._id;
 
         frisby.create('DELETE - should delete 2 documents')
-            .delete(url + 'delete/' + idFoundInDb + ',' + idCustomEncoded)
+            .delete(url + 'delete/' + idFoundInDb + '<sep>' + idCustomEncoded)
             .expectStatus(200)
         .toss();
 
@@ -362,7 +362,7 @@ frisby.create('CREATE - should create an object in the database')
             .after(function (error, response, body) {
 
             frisby.create('DELETE - should throw an error (not all document deleted)')
-                .delete(url + 'delete/' + idCustomEncoded + ',' + idNotFoundinDb)
+                .delete(url + 'delete/' + idCustomEncoded + '<sep>' + idNotFoundinDb)
                 .expectStatus(207)
             .toss();
 

--- a/server-tests/tests-frisby_spec.js
+++ b/server-tests/tests-frisby_spec.js
@@ -201,7 +201,7 @@ frisby.create('CREATE - should create an object in the database')
       * Tests for method Graph
       */
     //it always return a non empty array
-    frisby.create('GRAPH - should throw an error (id empty) - Not found')
+    frisby.create('GRAPH - should throw an error (id empty) - Bad Request')
         .get(url + 'graph/')
         .expectStatus(400)
     .toss();
@@ -308,9 +308,9 @@ frisby.create('CREATE - should create an object in the database')
     /**
      * Tests for method Delete
      */
-    frisby.create('DELETE - should throw an error (id empty)')
+    frisby.create('DELETE - should throw an error (id empty) - Bad Request')
         .delete(url + 'delete/')
-        .expectStatus(404)
+        .expectStatus(400)
     .toss();
 
     frisby.create('DELETE - should throw an error (id valid but not found in the DB)')


### PR DESCRIPTION
## Custom ids

* Positive aspects
  * easy and intuitive
  * doesn't need to search for getting an id
  * `#parent` key is set to asset name
  * doesn't need `file` key
  * really close to FileSystem
* Negative aspects
  * `,` or `<sep>` disallowed (split character, can be changed)
  * has to be unique
  * limited to 1024 bytes
  * not easy to rename an asset

Notes :
* To rename a node, a way to do it could be making a copy then delete the old node
* In aim to upgrade to Custom ids, the client has to :
  * modify all his database by :
    * changing all nodes containing `file` into the same having `_id` as `file`
    * replacing `#parent`, `src_id` and `tgt_id`
  * use create with `_id` instead of `file`
  * modify all his scripts using `search(file:/path/to/file)`