### PR TITLE
Fixes

### DIFF
--- a/server-nodejs/db/utils.js
+++ b/server-nodejs/db/utils.js
@@ -1,19 +1,19 @@
 
 global.array_sync = function (array, walker, callback) {
-    var next = 0;
-    var results = [];
-    (function walk() {
-        if (next === array.length) {
-            callback(results);
-            ++next;
-        } else if (next < array.length) {
-            walker(array[next++], function (result) {
-                results = results.concat(result);
-                process.nextTick(walk);
-            });
+    var iterator = {
+        count: array.length,
+        out: [],
+        next: function (i, res) {
+            this.out[i] = res;
+            if (0 === --this.count) {
+                callback(this.out);
+            }
         }
-    })();
-}
+    };
+    for (var index = 0; index < array.length; ++index) {
+        walker.apply(iterator, [array[index], index]);
+    }
+};
 
 /*
  * Attempt to fire an event, if the given array is valid
@@ -24,5 +24,20 @@ global.fireEvent = function (name, array) {
     if (0 < clean.length) {
         events.fire(name, clean);
     }
-}
+};
+
+global.unfoldIds = function (nodes) {
+    var array = [];
+    for (var i = 0; i < nodes.length; ++i) {
+        if (Array.isArray(nodes[i]._id)) {
+            array = array.concat(nodes[i]._id.map(function (id) {
+                return Object.assign({}, nodes[i], {_id: id});
+            }));
+        } else {
+            array.push(nodes[i]);
+        }
+    }
+    return array;
+};
+
 

--- a/server-nodejs/db/utils.js
+++ b/server-nodejs/db/utils.js
@@ -26,6 +26,9 @@ global.fireEvent = function (name, array) {
     }
 };
 
+/*
+ * Unfold the _id key of a node
+ */
 global.unfoldIds = function (nodes) {
     var array = [];
     for (var i = 0; i < nodes.length; ++i) {
@@ -39,5 +42,31 @@ global.unfoldIds = function (nodes) {
     }
     return array;
 };
+
+/*
+ * Polyfill for the native Object.assign() method
+ * Source: MDN
+ */
+if (typeof Object.assign != 'function') {
+    Object.assign = function (target) {
+        'use strict';
+        if (target == null) {
+            throw new TypeError('Cannot convert undefined or null to object');
+        }
+
+        target = Object(target);
+        for (var index = 1; index < arguments.length; index++) {
+            var source = arguments[index];
+            if (source != null) {
+                for (var key in source) {
+                    if (Object.prototype.hasOwnProperty.call(source, key)) {
+                        target[key] = source[key];
+                    }
+                }
+            }
+        }
+        return target;
+    };
+}
 
 


### PR DESCRIPTION
This pull request attemps to improve the server-side processing of requests.
It also solves the issue #130.

The DB calls were previously made in a synchronous fashion, sequentially (element per element). Now, these calls are made iteratively (that's the same but the name is better and we use a `for` loop) and asynchronously: the result array is filled whenever results are available, until there are no more results to add (and therefore no more holes in the result array).

This leads (on my laptop at least) to a huge performance gain (for the `read` operation at least).

Note: all tests were run without failures.