### PR TITLE
Major performance improvements

### DIFF
--- a/server-nodejs/db/utils.js
+++ b/server-nodejs/db/utils.js
@@ -1,20 +1,4 @@
 
-global.array_sync = function (array, walker, callback) {
-    var iterator = {
-        count: array.length,
-        out: [],
-        next: function (i, res) {
-            this.out[i] = res;
-            if (0 === --this.count) {
-                callback(this.out);
-            }
-        }
-    };
-    for (var index = 0; index < array.length; ++index) {
-        walker.apply(iterator, [array[index], index]);
-    }
-};
-
 /*
  * Attempt to fire an event, if the given array is valid
  */

--- a/server-nodejs/package.json
+++ b/server-nodejs/package.json
@@ -15,6 +15,7 @@
   "author": "Remy Lalanne <remy@primcode.com> http://primcode.com",
   "license": "GPL v3",
   "dependencies": {
+    "async": "^2.0.0-rc.5",
     "body-parser": "^1.13.2",
     "debug": "^2.2.0",
     "express": "^4.13.1",


### PR DESCRIPTION
This update implements a new algorithm for the `read` method, allowing fantastic response times (my laptop used to take ~11s to fetch 27k nodes. It now takes about ~1s!). It also halves the duration of the `update` method, as half of its time was spent in the `read` operation.

Note that this update is for the `experimental` branch, the one for the `testing` branch will come soon (I have some problems to solve before pushing a not-so-quick fix to `testing`).