### PR TITLE
Major performance improvements

### DIFF
--- a/server-nodejs/db/mongodb.js
+++ b/server-nodejs/db/mongodb.js
@@ -97,14 +97,21 @@ module.exports = function (conf) {
             var query = self.querify(ids);
             var idHash = {};
             for (var i = 0; i < ids.length; ++i) {
-                idHash[ids[i]] = i;
+                if (Array.isArray(idHash[ids[i]])) {
+                    idHash[ids[i]].push(i);
+                } else {
+                    idHash[ids[i]] = [i];
+                }
             }
             coll.find(query).toArray(function (err, nodes) {
                 if (err) {
                     return callback(true);
                 }
                 callback(false, nodes.reduce(function (res, node) {
-                    res[idHash[node._id.toString()]] = node;
+                    var id = node._id.toString();
+                    for (var i = 0; i < idHash[id].length; ++i) {
+                        res[idHash[id][i]] = node;
+                    }
                     return res;
                 }, ids.map(function () { return null; })));
             });

--- a/server-nodejs/db/utils.js
+++ b/server-nodejs/db/utils.js
@@ -1,0 +1,28 @@
+
+/*
+ * Polyfill for the native Object.assign() method
+ * Source: MDN
+ */
+if (typeof Object.assign != 'function') {
+    Object.assign = function (target) {
+        'use strict';
+        if (target == null) {
+            throw new TypeError('Cannot convert undefined or null to object');
+        }
+
+        target = Object(target);
+        for (var index = 1; index < arguments.length; index++) {
+            var source = arguments[index];
+            if (source != null) {
+                for (var key in source) {
+                    if (Object.prototype.hasOwnProperty.call(source, key)) {
+                        target[key] = source[key];
+                    }
+                }
+            }
+        }
+        return target;
+    };
+}
+
+

--- a/server-nodejs/package.json
+++ b/server-nodejs/package.json
@@ -15,6 +15,7 @@
   "author": "Remy Lalanne <remy@primcode.com> http://primcode.com",
   "license": "GPL v3",
   "dependencies": {
+    "async": "^2.0.0-rc.5",
     "body-parser": "^1.13.2",
     "debug": "^2.2.0",
     "express": "^4.13.1",
@@ -26,7 +27,8 @@
     "mongodb": "^2.1.0-alpha",
     "morgan": "^1.6.1",
     "multer": "^0.1.8",
-    "ncp": "^2.0.0"
+    "ncp": "^2.0.0",
+    "socket.io": "^1.4.6"
   },
   "devDependencies": {
     "frisby": "^0.8.5"


### PR DESCRIPTION
This update implements a new algorithm for the read method, allowing fantastic response times (my laptop used to take ~11s to fetch 27k nodes. It now takes about ~1s!). It also halves the duration of the update method, as half of its time was spent in the read operation.

It is a not-so-quick fix to use until we are able to push the `experimental` branch in place of the `testing` branch.

Regarding tests ran on the production server, we still encounter the `process.nextTick` problem with large reads. It is likely that this error is raised by Node when encoutering too many `nextTick` calls in a given amount of time.

However, as we perform only one query to MongoDB, there is only one asynchronous function call, and therefore we can't have a `process.nextTick` loop. I do not understand why does this problem keeps happening. Maybe we need to upgrade our npm dependencies?