### PR TITLE
Solve the JSON encoding problem

### DIFF
--- a/server-nodejs/routes/cruds.js
+++ b/server-nodejs/routes/cruds.js
@@ -121,17 +121,16 @@ module.exports = function (app, express) {
                 res.send('Id not found');
                 return;
             }*/
-            res.setHeader('Content-Type', 'application/json');
+            res.setHeader('Content-Type', 'application/json; charset=utf-8');
             res.status(200);
-            res.write('[');
-            doc.forEach(function (obj, id) {
-                res.write(JSON.stringify(obj));
-                if(doc.length - 1 !== id) {
-                    res.write(',');
-                }
-            });
-            res.write(']');
-            res.end();
+            res.write('[' + JSON.stringify(doc.shift()));
+            var chunkSize = 100;
+            for (var i = 0; i < doc.length; i += chunkSize) {
+                res.write(',' +
+                    JSON.stringify(doc.slice(i, i + chunkSize))
+                    .slice(1, -1));
+            }
+            res.end(']');
         });
     }; // read()
 


### PR DESCRIPTION
This is so working that it is now as great as it was expected to be before it worked. :octopus: 

> Test data: all the DB (~63 MB of JSON).
> Only the time spent in emitting data is recorded.

By converting elements or chunks to JSON by batches:
- Send one object by one iteratively: 4.5s
- Send one object by one while removing them with `Array.shift()`: 32s (but strictly no memory footprint!)
- Send objects by chunks iteratively: 850ms (choosen method)
- Send objects by chunks while removing them with `Array.splice()`: don't do that (+ I forgot how many time it took)

Other tests case for which I don't remember the benchmark results:
- When we first convert all the data to a JSON string, sending the whole object at once (don't do that)
- When we first convert all the data to a JSON string, sending chunks (maybe good?)
- When we convert all the data to a JSON string to a Buffer, sending it by chunks or at once: ~1.5s slower than the two previous tests, but allows us to set the `Content-Length` header. We can't set it otherwise as JS's native strings do not handle well Unicode or something like that.

=> There are no longer problems with the reading of JSON strings by Python.