### PR TITLE
fix #144 root appears as /. instead of /

### DIFF
--- a/cli/damas.sh
+++ b/cli/damas.sh
@@ -196,7 +196,7 @@ get_ids() {
 }
 
 get_real_path() {
-  FILEPATH="/"$(realpath --relative-to $DIRECTORY $1)
+  FILEPATH="/"$(realpath --relative-base $DIRECTORY $1 | sed 's/\.$//')
 }
 
 upsearch() {


### PR DESCRIPTION
Note that we don't verify if the file is outside the repo.
The only verification is on PWD
In case the file is outside, his absolute path is his id