### PR TITLE
Implementation of author based permissions for operations. Fixes #189

### DIFF
--- a/server-nodejs/conf_install.json
+++ b/server-nodejs/conf_install.json
@@ -1,5 +1,6 @@
 {
     "auth" : "no",
+    "authorMode" : true,
     "connection" : {
         "Cert": "cert.pem",
         "Key": "key.pem"

--- a/server-nodejs/routes/permissions.js
+++ b/server-nodejs/routes/permissions.js
@@ -11,7 +11,7 @@ module.exports = function (app) {
 
         var isOperationAllowed = tools.isOperationAllowed(req.params.route, req.user.class);
         if(['read', 'update'].indexOf(req.params.route) === -1) {
-            if(!isFromClass) {
+            if(!isOperationAllowed) {
                 return httpStatus(res, 403, 'Access ' + req.params.route);
             }
             next();

--- a/server-nodejs/routes/perms-tools.js
+++ b/server-nodejs/routes/perms-tools.js
@@ -40,8 +40,8 @@ module.exports = function(app) {
             return table;
         };
 
-        module.isFromClass = function(req) {
-            switch (req.params.route) {
+        module.isOperationAllowed = function(operationName, userClass) {
+            switch (operationName) {
             case 'lock':
             case 'unlock':
             case 'publish':
@@ -50,7 +50,7 @@ module.exports = function(app) {
             case 'file':
             case 'comment':
                 // User class must be at least 'user'
-                if (['user', 'editor', 'admin'].indexOf(req.user.class) === -1) {
+                if (['user', 'editor', 'admin'].indexOf(userClass) === -1) {
                     return false;
                 }
                 break;
@@ -59,7 +59,7 @@ module.exports = function(app) {
             case 'upsert':
             case 'delete':
                 // User class must be at least 'editor'
-                if (['editor', 'admin'].indexOf(req.user.class) === -1) {
+                if (['editor', 'admin'].indexOf(userClass) === -1) {
                     return false;
                 }
                 break;

--- a/server-nodejs/routes/perms-tools.js
+++ b/server-nodejs/routes/perms-tools.js
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the GNU GPL v3
+ */
+module.exports = function(app) {
+    var db = app.locals.db;
+    var module = {};
+        module.extractIds = function(nodes) {
+            var ids = [];
+            nodes = unfoldIds(nodes);
+            for(var i in nodes) {
+                ids.push(nodes[i]._id);
+            }
+            return ids;
+        };
+
+        module.filterByAuthor = function(ids, username, callback) {
+            var perms = [];
+            db.read(ids, function(err, nodes) {
+                for(var i in nodes) {
+                    if(nodes[i] === null) {
+                        perms.push(true);
+                        continue;
+                    }
+                    if(nodes[i].author !== username) {
+                        perms.push(false);
+                        continue;
+                    }
+                    perms.push(true);
+                }
+                callback(perms);
+            });
+        };
+
+        module.filterRequest = function(table, perms) {
+            for(var i in table) {
+                if(perms[i] === false) {
+                    table.splice(i, 1, 'null');
+                }
+            }
+            return table;
+        };
+
+        module.isFromClass = function(req) {
+            switch (req.params.route) {
+            case 'lock':
+            case 'unlock':
+            case 'publish':
+            case 'upload':
+            case 'version':
+            case 'file':
+            case 'comment':
+                // User class must be at least 'user'
+                if (['user', 'editor', 'admin'].indexOf(req.user.class) === -1) {
+                    return false;
+                }
+                break;
+            case 'update':
+            case 'create':
+            case 'upsert':
+            case 'delete':
+                // User class must be at least 'editor'
+                if (['editor', 'admin'].indexOf(req.user.class) === -1) {
+                    return false;
+                }
+                break;
+            }
+            return true;
+        };
+        return module;
+};
+
+


### PR DESCRIPTION
# Author based permissions
For further improvement, we have to consider fixing `db.update` in order for it to accept nulls. That way, the result can be returned with the correct status code. (207 when some nodes aren't ours, 403 when all nodes aren't ours)
When the request is filtered and is only filled with 'null', we could expect 403 error (Forbidden).