### PR TITLE
JWT improvements

### DIFF
--- a/server-nodejs/conf_install.json
+++ b/server-nodejs/conf_install.json
@@ -16,17 +16,21 @@
             "path": "./extensions/es6_polyfills.js"
         },
         "jwt": {
-			"enable": false,
+            "enable": false,
             "path": "./extensions/auth-jwt-node.js",
             "conf": {
                 "required": false,
                 "passwordHashAlgorithm": "sha1",
                 "secret": "webtokensecret",
-                "exp": 1440
+                "exp": 1440,
+                "expressUse": "/api",
+                "expressUnless": {
+                    "path": "/api/signIn"
+                }
             }
         },
         "noauth": {
-			"enable": true,
+            "enable": true,
             "path": "./extensions/auth-none.js"
         },
         "prefer_https": {

--- a/server-nodejs/extensions/auth-jwt-node.js
+++ b/server-nodejs/extensions/auth-jwt-node.js
@@ -45,13 +45,6 @@ module.exports = function (app) {
         return func;
     };
 
-    app.use(cookieParser())
-    app.use('/api', middleware().unless({path:['/api/signIn']}));
-
-    //var jwtMiddleware = expressJwt({secret:conf.secret});
-    //jwtMiddleware.unless = unless;
-    //app.use('/api', jwtMiddleware.unless({path:['/api/signIn']}));
-
     var authenticate = function (req, res, next) {
         debug('Processing authenticate middleware');
         if (!req.body.username || !req.body.password) {
@@ -149,6 +142,9 @@ module.exports = function (app) {
     app.route('/api/signIn').post(authenticate, function (req, res, next) {
         return res.status(200).json(req.user);
     });
+
+    app.use(cookieParser());
+    app.use(conf.expressUse, middleware().unless(conf.expressUnless));
 }
 
 

--- a/server-nodejs/extensions/auth-jwt-node.js
+++ b/server-nodejs/extensions/auth-jwt-node.js
@@ -91,7 +91,10 @@ module.exports = function (app) {
             var part = authorization.split(' ');
             if (part.length === 2) {
                 var token = part[1];
-                return part[1];
+                if ('null' === token) {
+                    token = null;
+                }
+                return token;
             } else {
                 return null;
             }


### PR DESCRIPTION
## Token in cookie

The token in the cookie was unreachable because when a damas client sends a request without a token, it send `Authorization: Bearer null` in the header. The `null` was interpreted as the token string.

## Scope in config

Both `app.use()` and `unless()` can be defined in the configuration. See [express doc](http://expressjs.com/en/4x/api.html#path-examples) for the first part and [express-unless](https://www.npmjs.com/package/express-unless) for the second part