### PR TITLE
New extension: Restricted Keys

### DIFF
--- a/server-nodejs/conf_install.json
+++ b/server-nodejs/conf_install.json
@@ -52,6 +52,20 @@
             "enable": true,
             "path": "./extensions/auth-none.js"
         },
+        "restricted_keys": {
+            "enable": true,
+            "path": "./extensions/restricted_keys.js",
+            "conf": {
+                "whitelist": ["admin"],
+                "override": {
+                    "active": false,
+                    "author": null,
+                    "class": null,
+                    "time": null,
+                    "username": null
+                }
+            }
+        },
         "prefer_https": {
             "enable": false,
             "path": "./extensions/prefer_https.js"

--- a/server-nodejs/extensions/restricted_keys.js
+++ b/server-nodejs/extensions/restricted_keys.js
@@ -1,0 +1,38 @@
+module.exports = function (app) {
+    var conf = app.locals.conf.restricted_keys;
+
+    /**
+     * Replace keys by default ones if the user is not in the whitelist
+     * If the new value is defined as null, delete the key from the request
+     */
+    app.use('/api/', function (req, res, next) {
+        if (conf.whitelist.indexOf(req.user.class) !== -1) {
+            next();
+            return;
+        }
+
+        if (Array.isArray(req.body)) {
+            for (var i in req.body) {
+                req.body[i] = override(req.body[i]);
+            }
+        } else {
+            req.body = override(req.body);
+        }
+
+        next();
+    });
+
+    function override(node) {
+        Object.keys(node).forEach(function (key) {
+            var newValue = conf.override[key];
+            if (newValue !== undefined) {
+                if (newValue === null) {
+                    delete node[key];
+                    return;
+                }
+                node[key] = newValue;
+            }
+        });
+        return node;
+    }
+}


### PR DESCRIPTION
This new extension is really simple.
It first checks the user's `class`. If it is not **white-listed**, it replaces all keys as in the configuration.
There is an exception for `null` : it is usually used to remove a key from a node. We don't want users to be able to do that and we don't want a null in a value of a node. So the extension simply removes the key from the request.

fixes #212 