### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/server-php/file.php
+++ b/server-php/file.php
@@ -36,7 +36,7 @@ switch( arg("cmd") )
 	case "sha1":
 		checkfilefound( $assetsLCL . arg("path") );
 		$sha1 = sha1_file( $assetsLCL . arg("path") );
-		if( $sha1 === FALSE )
+		if( $sha1 === false )
 		{
 			header("HTTP/1.1: 409 Conflict");
 			echo "sha1_file( ". $assetsLCL . arg("path") . " ) returned FALSE";

--- a/server-php/lib/model.php
+++ b/server-php/lib/model.php
@@ -103,7 +103,7 @@ class model
 	 * @param {String} limit Limit and offset for result (MySQL Syntax)
 	 * @returns {Array} array of matching node indexes
 	 */
-	static function search ( $keys, $sortby = 'label', $order = 'DESC', $limit = NULL )
+	static function search ( $keys, $sortby = 'label', $order = 'DESC', $limit = null )
 	{
 		if( $keys === null )
 		{


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!