### PR TITLE
jwt_delegate startup

### DIFF
--- a/server-nodejs/conf_template.json
+++ b/server-nodejs/conf_template.json
@@ -34,6 +34,13 @@
             "enable": true,
             "path" : "./extensions/user_setup.js"
         },
+        "jwt_delegate": {
+            "enable": false,
+            "path": "./extensions/jwt_delegate.js",
+            "conf": { 
+                "server": "http://localhost:3000/api/signIn/"
+            }
+        },
         "jwt": {
             "enable": false,
             "path": "./extensions/jwt.js",

--- a/server-nodejs/extensions/jwt.js
+++ b/server-nodejs/extensions/jwt.js
@@ -63,7 +63,7 @@ module.exports = function (app) {
                 user.address = req.connection.remoteAddress;
                 user.class = user.class || 'guest';
                 req.user = {_id: user._id, user: user, token: jwt.sign(payload, conf.secret + user.password, options)};
-                debug('Token generated for user: %s, token: %s', user.username, user.token);
+                debug('Token generated for user: %s, token: %s', user.username, req.user.token);
                 return res.status(200).json(req.user);
             });
         });

--- a/server-nodejs/extensions/jwt_delegate.js
+++ b/server-nodejs/extensions/jwt_delegate.js
@@ -5,58 +5,65 @@
  *
  *
  */
- 
+
 module.exports = function (app) {
-    var db  = app.locals.db;
+    var db = app.locals.db;
     //let XHR = require('xmlhttprequest-ssl');
     var XMLHttpRequest = require("xmlhttprequest-ssl").XMLHttpRequest;
     var debug = require('debug')('damas:extensions:jwt_delegate');
 
-
     var server = app.locals.conf.jwt_delegate.server;
-    
+
     app.use('/api/signIn', function (req, res, next) {
-	    debug(server);
+        debug(server);
         if ('undefined' != req.body.username) {
             var xhr = new XMLHttpRequest();
             xhr.onerror = function () {
-	    debug(server);
-                console.error("Connection impossible with " + "'" + server + "'");
+                debug(server);
+                console.error("Error request");
+                next();
             }
-            //xhr.onload = function (err) {
             xhr.onreadystatechange = function (err) {
-                if (405 === this.status) {
-                    this.onerror();   
-                }
-                if (4 === this.readyState && 200 === this.status) { 
-                    var response = JSON.parse(this.responseText);
-                    if (undefined === response.user) {
-                        console.warn("Impossible authentication with that version of damas.core. Please, update damas-core or disabled jwt_delegate extention.");
-                        return next();
-                    }
-                    db.create([response.user], function (err, nodes) {
-                        if (err) {
-                            console.warn("Creation user node impossible in the database.");
+                if (4 === this.readyState) {
+                    if (200 === this.status) {
+                        var response = JSON.parse(this.responseText);
+                        if (undefined === response.user) {
+                            console.warn("Impossible authentication with that version of damas.core. Please, update damas-core or disabled jwt_delegate extention.");
                             return next();
                         }
-                        if (null === nodes[0]) {
-                            db.update([response.user], function (err, doc) {
-                                if (err) {
-                                    console.warn("Updating user node impossible.");
+                        db.create([response.user], function (err, nodes) {
+                            if (err) {
+                                console.warn("Creation user node impossible in the database.");
+                                return next();                        
+                            }
+                            if (null === nodes[0]) {
+                                db.update([response.user], function (err, doc) {
+                                    if (err) {
+                                        console.warn("Updating user node impossible.");
+                                        return next();
+                                    }
                                     return next();
-                                }
-                            });
-                        }
-                    });
+                                });
+                            } else {
+                                return next();
+                            }
+                        });
+                    } else if (this.status >= 500) {
+                        debug(server);
+                        console.warn("No response from the server " + "'" + server + "'" + " for your request. Please check the server URL in the conf.json.");
+                        return next();
+                    } else if (this.status === 401) {
+                        debug(server);
+                        console.warn("Invalid username or passeword");
+                        return next();
+                    }
                 }
             }
             xhr.open("POST", server, true);
             xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
             var login = "username=" + req.body.username + "&password=" + req.body.password;
-	    debug(login);
+            debug(login);
             xhr.send(login);
         }
-        next();
     });
 }
-


### PR DESCRIPTION
Adds the jwt_delegate extension to the configuration file and is disabled by default. This addition also includes the url of a server that will receive the delegation of the authentication procedure.
jwt_gelegate is blocking. That is, as long as the verification by the delegated server is not accomplished, the following extension is not executed.
When the request response is retrieved, the "onreadystatechange" callback is executed.
The cases covered by the callback are : 
  - code 200 : the user's node is retrieved, we try to create it locally or we update it. Then we execute the following extension.
  - code >= 500 : it means url errors or server crashes.
  - code 401 : the authentication of the user on the delegated server has failed.