### PR TITLE
Apikey generation and authentication using Apikey #279

### DIFF
--- a/cli/damas
+++ b/cli/damas
@@ -18,7 +18,7 @@
 # with damas-core.  If not, see <http://www.gnu.org/licenses/>.
 
 # VARIABLES
-USER=`whoami`
+USER=$(whoami)
 CURL_ARGS='-ksL -w "\n%{http_code}" -H "Content-Type: application/json"'
 BUFFER_SIZE=1000
 
@@ -63,7 +63,7 @@ map_server_errors() {
       echo "Internal server error (server error 500)" >&2
       return 50
       ;;
-    *)   # Unknown server error
+    *) # Unknown server error
       echo "Unknown server error" >&2
       return 60
       ;;
@@ -93,25 +93,15 @@ run() {
   fi
 }
 
-load_token() {
-  if [ $DAMAS_TOKEN ]; then
-    local TOKEN=$DAMAS_TOKEN
-  else
-    local TOKEN_FILE="/tmp/damas-$USER-$(echo -n $DAMAS_SERVER | cksum | head -c 10)"
-    local TOKEN=$(cat $TOKEN_FILE 2> /dev/null)
-  fi
-
-  AUTH='-H "Authorization: Bearer '$TOKEN'"'
-}
-
 show_help_msg() {
-  echo "usage: damas [--help] [-s|--server <server_url>] [-q|--quiet] [-v|--verbose] [-l|--lines] <COMMAND> [<ARGS>]"
+  echo "usage: damas [--help] [-s|--server <server_url>] [-q|--quiet] [-v|--verbose] [-l|--lines] [--apikey <DAMAS_TOKEN>] <COMMAND> [<ARGS>]"
   echo ""
   echo "When ARGS is -, read standard input."
   echo ""
   echo "Authentication commands: "
   echo "   signin    <username> <pass> [<lifespan>] or without arguments for interactive sign in"
   echo "   signout   Remove authorization token"
+  echo "   --apikey <DAMAS_TOKEN>  Use the provided API key for authentication"
   echo ""
   echo "CRUDS commands (send JSON to the server, see examples below):"
   echo "   create       <json>  insert object(s)"
@@ -193,6 +183,10 @@ while true; do
       DAMAS_SERVER=$2
       shift 2
       ;;
+    --apikey)
+      DAMAS_TOKEN=$2
+      shift 2
+      ;;
     -*)
       echo "Unknown option: $1"
       exit 1
@@ -202,6 +196,21 @@ while true; do
       ;;
   esac
 done
+
+TOKEN_FILE="/tmp/damas-$USER-$(echo -n $DAMAS_SERVER | cksum | head -c 10)"
+
+load_token() {
+  if [ -n "$DAMAS_TOKEN" ]; then
+    local TOKEN="$DAMAS_TOKEN"
+  else
+    local TOKEN=$(cat "$TOKEN_FILE" 2>/dev/null)
+  fi
+  if [ -n "$TOKEN" ]; then
+    AUTH='-H "Authorization: Bearer '$TOKEN'"'
+  else
+    AUTH=""
+  fi
+}
 
 COMMAND=$1
 shift
@@ -221,7 +230,7 @@ fi
 load_token
 
 if [ "$1" == "-" ]; then
-  DATA=@/dev/stdin 
+  DATA=@/dev/stdin
 else
   DATA=$*
 fi
@@ -271,16 +280,14 @@ case $COMMAND in
       printf "\n\n"
     fi
     RES=$(eval "curl $CURL_VERBOSE -ks -w \"\n%{http_code}\" --fail -d 'username=$USERN&password=${PASS}${expiresIn}' ${DAMAS_SERVER}/api/signIn/")
-    TOKEN=$(echo $RES| sed 's/^.*"token":"\([^"]*\)".*$/\1/')
-    TOKEN_FILE="/tmp/damas-$USER-$(echo -n $DAMAS_SERVER | cksum | head -c 10)"
+    TOKEN=$(echo $RES | sed 's/^.*"token":"\([^"]*\)".*$/\1/')
     echo $TOKEN
-    echo $TOKEN > $TOKEN_FILE
+    echo $TOKEN >"$TOKEN_FILE"
     chmod go-rw "$TOKEN_FILE"
     map_server_errors "${RES##*$'\n'}"
     exit $?
     ;;
   signout)
-    TOKEN_FILE="/tmp/damas-$USER-$(echo -n $DAMAS_SERVER | cksum | head -c 10)"
     rm "$TOKEN_FILE"
     exit 0
     ;;

--- a/js/createToken.html
+++ b/js/createToken.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Generate Token</title>
+    <script src="/js/damas.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            damas.server = '';
+            document.querySelector('#generate-token-form').addEventListener('submit', function(e) {
+                e.preventDefault();
+                const lifespan = document.querySelector('#lifespan').value;
+                damas.createToken(lifespan, function(err, result) {
+                    if (err) {
+                        alert('Error generating token: ' + err.message);
+                    } else {
+                        const tokenElement = document.querySelector('#token');
+                        tokenElement.value = result; // Change textContent to value
+                        tokenElement.select();
+                        document.execCommand('copy');
+                        alert('New token generated and copied to clipboard');
+                    }
+                });
+            });
+        });
+    </script>
+</head>
+<body>
+    <h1>Generate New Token</h1>
+    <form id="generate-token-form">
+        <label for="lifespan">Lifespan (milliseconds by default, check the ms lib):</label>
+        <input type="number" id="lifespan" name="lifespan">
+        <button type="submit">Generate Token</button>
+    </form>
+    <textarea id="token" readonly></textarea>
+</body>
+</html>

--- a/js/damas.js
+++ b/js/damas.js
@@ -79,7 +79,7 @@
                 return null;
             }
         }
-        xhr.onreadystatechange = function(e) {
+        xhr.onreadystatechange = function (e) {
             if (4 === xhr.readyState) {
                 if (args.async && 'function' === typeof args.callback) {
                     args.callback(checkXHR());
@@ -87,7 +87,7 @@
             }
         }
         xhr.open(args.method, damas.server + args.url, args.async);
-        if(damas.token) {
+        if (damas.token) {
             xhr.setRequestHeader('Authorization', 'Bearer ' + damas.token);
         }
         if (undefined !== args.data) {
@@ -282,25 +282,25 @@
     }
 
 
-/* this is the php version as reference
-    damas.search = function (keys, sortby, order, limit, callback) {
-        function req_callback(req) {
-            return JSON.parse(req.transport.responseText);
-        }
-        var req = new Ajax.Request(this.server + "/model.json.php", {
-            asynchronous: callback !== undefined,
-            parameters: { cmd: 'search', keys: Object.toJSON(keys), sortby: sortby || 'label', order: order || 'ASC', limit: limit },
-            onSuccess: function(req) {
-                if (callback) {
-                    callback(req_callback(req));
-                }
+    /* this is the php version as reference
+        damas.search = function (keys, sortby, order, limit, callback) {
+            function req_callback(req) {
+                return JSON.parse(req.transport.responseText);
             }
-        });
-        if (callback === undefined) {
-            return req_callback(req);
+            var req = new Ajax.Request(this.server + "/model.json.php", {
+                asynchronous: callback !== undefined,
+                parameters: { cmd: 'search', keys: Object.toJSON(keys), sortby: sortby || 'label', order: order || 'ASC', limit: limit },
+                onSuccess: function(req) {
+                    if (callback) {
+                        callback(req_callback(req));
+                    }
+                }
+            });
+            if (callback === undefined) {
+                return req_callback(req);
+            }
         }
-    }
-*/
+    */
 
     /**
      * Recursively get all links and nodes sourced by the specified node
@@ -454,6 +454,30 @@
         }
     }
 
+
+
+    /**
+     * Create a valid json web token, usable in the cli
+     * @param {String} expiresIn the token's lifespan in ms, using the 'ms' package format
+     * @return the token generated
+     */
+    damas.createToken = function (expiresIn, callback) {        
+        let form = '';
+        if (undefined != expiresIn && 'function' != typeof expiresIn) {
+            form += '&expiresIn=' + encodeURIComponent(expiresIn);
+        } else {
+            callback = expiresIn;
+        }
+        return req({
+            method: 'POST',
+            url: '/api/createToken/',
+            form: form,
+            callback: callback
+        });
+    };    
+    
+    
+    
     /**
      * Sign out using the server embeded authentication system
      */
@@ -491,7 +515,7 @@
     damas.search_rest = damas.search;
     damas.graph_rest = damas.graph;
 
-	console.log('damas-core API loaded')
+    console.log('damas-core API loaded')
 
     return damas;
 

--- a/server-nodejs/extensions/jwt.js
+++ b/server-nodejs/extensions/jwt.js
@@ -132,5 +132,21 @@ module.exports = function (app) {
         res.status(200).json(req.user);
     });
 
+    
+    app.route('/api/createToken').post(function (req, res, next) {  
+        var expiresIn = req.body.expiresIn || conf.exp;   
+        var payload = {
+            _id: req.user._id,
+            username: req.user.username,
+            ignoreExpiration: expiresIn === '0'
+        };    
+        var options = {
+            expiresIn: expiresIn
+        };    
+        var token = jwt.sign(payload, conf.secret + req.user.password, options);        
+        res.status(200).json(token);        
+        
+    });
+
 }
 


### PR DESCRIPTION
Responding to the https://github.com/remyla/damas-core/issues/279 issue , dealing with Apikeys (third version).

- Provides an Html view where logged in users can generate Tokens, with a chosen lifespan in milliseconds. View is createToken.html , and is accessible in the js/index.html .
- Added an option in the cli/damas : Users can now bypass the signin procedure. They can precize " --apikey <api_key> " (with api_key being the token generated by the view mentionned above) before their command, which allows them to do operations (such as a search, create, ...) , without having to sign in. Since it is an option, users can still sign in and providing an apy key is not mandatory .