### PR TITLE
Fix: docker action conditions and repository

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,8 +29,7 @@ jobs:
   push_image:
     name: Push Docker image
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag' ||
-      contains(fromJSON('["master", "testing", "experimental"]'), github.ref_name)
+    if: github.ref_type == 'tag'
     needs: tests
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +40,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
 
       - uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
I just realized you wanted to push the docker image only on new tags.
Plus when I created the push_image action, I thought the Docker Hub repository name was the same as the Github repository name. So I changed the repository name by using the same username as the authentication